### PR TITLE
feat(wls): Add dd-policy-compile CLI

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,8 +10,8 @@ ARG GO_VER="1.24.4"
 ARG CLANG_VERSION=18
 
 RUN apk update \
- && apk add musl-dev gcc make python3 patchelf bash clang${CLANG_VERSION} clang${CLANG_VERSION}-extra-tools clang${CLANG_VERSION}-rtlib \
-    llvm${CLANG_VERSION} ruff ninja-build git
+    && apk add musl-dev gcc make python3 patchelf bash clang${CLANG_VERSION} clang${CLANG_VERSION}-extra-tools clang${CLANG_VERSION}-rtlib \
+    llvm${CLANG_VERSION} ruff ninja-build git xxd g++
 
 # for some reason clang-format installation dir is not included in PATH
 ENV PATH="$PATH:/usr/lib/llvm18/bin/"
@@ -43,11 +43,11 @@ RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/m
 # Add flatcc
 ARG FLATCC_COMMIT_ID=47af7e6
 RUN cd ~ \
- && git clone https://github.com/dvidelabs/flatcc.git \
- && cd flatcc \
- && git reset --hard $FLATCC_COMMIT_ID \
- && CMAKE_POLICY_VERSION_MINIMUM=3.5 scripts/initbuild.sh make-concurrent \
- && CMAKE_POLICY_VERSION_MINIMUM=3.5 ./scripts/build.sh
+    && git clone https://github.com/dvidelabs/flatcc.git \
+    && cd flatcc \
+    && git reset --hard $FLATCC_COMMIT_ID \
+    && CMAKE_POLICY_VERSION_MINIMUM=3.5 scripts/initbuild.sh make-concurrent \
+    && CMAKE_POLICY_VERSION_MINIMUM=3.5 ./scripts/build.sh
 RUN cp ~/flatcc/bin/flatcc /usr/bin/
 RUN cp -r ~/flatcc/include/flatcc /usr/include/
 RUN cp ~/flatcc/lib/libflatcc.a /usr/lib/

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,19 @@ include Makefile.docker
 
 %-all: 
 	$(DOCKER_RUN) make -C $(patsubst %-all,%,$@) all
-all: build-container $(addsuffix -all,$(LANGUAGES)) examples
+all: build-container build-dd-compile-policy $(addsuffix -all,$(LANGUAGES)) examples
 
+build-dd-compile-policy:
+	$(DOCKER_RUN) make -C dd-compile-policy build
+
+clean-dd-compile-policy:
+	$(DOCKER_RUN) make -C dd-compile-policy clean
+
+fmt-dd-compile-policy:
+	$(DOCKER_RUN) make -C dd-compile-policy fmt
+
+fmt-dd-compile-policy-check:
+	$(DOCKER_RUN) make -C dd-compile-policy fmt-check
 
 %-examples:
 	$(DOCKER_RUN) make -C $(patsubst %-examples,%,$@) examples
@@ -28,11 +39,11 @@ examples: build-container $(addsuffix -examples,$(LANGUAGES))
 %-fmt-check: build-container
 	$(DOCKER_RUN) make -C $(patsubst %-fmt-check,%,$@) fmt-check
 
-clean: $(addsuffix -clean,$(LANGUAGES))
+clean: $(addsuffix -clean,$(LANGUAGES)) clean-dd-compile-policy
 
-fmt: $(addsuffix -fmt,$(LANGUAGES))
+fmt: $(addsuffix -fmt,$(LANGUAGES)) fmt-dd-compile-policy
 
-fmt-check: $(addsuffix -fmt-check,$(LANGUAGES))
+fmt-check: $(addsuffix -fmt-check,$(LANGUAGES)) fmt-dd-compile-policy-check
 
 generate-jsonschema: build-container
 	@$(DOCKER_RUN) echo "[i] generating JSON schema in: $(JSONSCHEMA_OUT_PATH)"
@@ -60,4 +71,3 @@ ifeq ($(IN_DOCKER),false)
 			$(DOCKER_REPO):dd-policy-engine-$(COMMIT_SHA)-arm64
 	docker push $(DOCKER_REPO):dd-policy-engine-$(COMMIT_SHA)
 endif
-

--- a/dd-compile-policy/.gitignore
+++ b/dd-compile-policy/.gitignore
@@ -1,0 +1,5 @@
+flatbuffers-*
+src/*_bfbs.h
+bin
+schema
+include/cxxopts.hpp

--- a/dd-compile-policy/Makefile
+++ b/dd-compile-policy/Makefile
@@ -1,0 +1,110 @@
+FLATBUFFERS_VERSION = 25.9.23
+FLATBUFFERS_TARBALL = flatbuffers-v$(FLATBUFFERS_VERSION).tar.gz
+FLATBUFFERS_DIR = flatbuffers-$(FLATBUFFERS_VERSION)
+FLATBUFFERS_PATCH = ../flatbuffers.patch # relative to FLATBUFFERS_DIR
+
+CXXOPTS_VERSION = 3.2.1
+BUILD_DIR = $(FLATBUFFERS_DIR)/build
+SRC = src/compile_policy.cpp
+OUT = bin/dd-compile-policy
+# Include headers and source files for formatting
+FILES_TO_FORMAT = $(wildcard ./*/*.cpp ./*/*.hpp ./*/*.c ./*/*.h)
+
+CXX = g++
+CXXFLAGS = -std=c++17 -Os -flto -g0 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fvisibility=hidden -fvisibility-inlines-hidden -DCXXOPTS_NO_EXCEPTIONS -DCXXOPTS_NO_RTTI
+LDFLAGS = 
+ifeq ($(shell uname), Linux)
+	CXXFLAGS += -static -static-libgcc -static-libstdc++
+	LDFLAGS += -Wl,--gc-sections -Wl,--strip-all -Wl,--as-needed
+endif
+INCLUDES = -I$(FLATBUFFERS_DIR)/include -Isrc -Iinclude
+LIBS = $(BUILD_DIR)/libflatbuffers.a
+CXXOPTS_HEADER = include/cxxopts.hpp
+
+# Get the directory of the current Makefile
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+SCHEMA_PATH = $(MAKEFILE_DIR)/../fbs-schema/policy.fbs
+POLICY_BFBS = schema/policy.bfbs
+POLICY_BFBS_HEADER = src/policy_schema_bfbs.h
+
+STRIP = strip
+
+.PHONY: all clean flatbuffers strip_binary
+
+all: build
+
+build: flatbuffers $(CXXOPTS_HEADER) $(POLICY_BFBS) $(POLICY_BFBS_HEADER) $(OUT) strip_binary
+
+# Download cxxopts header (pinned to version $(CXXOPTS_VERSION))
+$(CXXOPTS_HEADER):
+	mkdir -p include
+	wget -O $@ https://raw.githubusercontent.com/jarro2783/cxxopts/v$(CXXOPTS_VERSION)/include/cxxopts.hpp
+
+# Download & extract flatbuffers
+$(FLATBUFFERS_TARBALL):
+	wget -O $@ https://github.com/google/flatbuffers/archive/refs/tags/v$(FLATBUFFERS_VERSION).tar.gz
+
+$(FLATBUFFERS_DIR): $(FLATBUFFERS_TARBALL)
+	tar -xzf $<
+
+# Flatbuffers isn't working too well on musl, so we need to patch it.
+# See https://github.com/sartura/flatbuffers/commit/92bd62407329caacd66e92e5bfd2949f2f137bfe
+patch_flatbuffers_musl:
+	@echo "Patching flatbuffers base.h for musl compatibility..."
+	@cd ./$(FLATBUFFERS_DIR) && git apply -p0 $(FLATBUFFERS_PATCH) ; cd -
+
+# Build Flatbuffers static library
+$(BUILD_DIR)/libflatbuffers.a: $(FLATBUFFERS_DIR) patch_flatbuffers_musl
+	mkdir -p $(BUILD_DIR)
+ifeq ($(shell uname), Linux)
+	cd $(BUILD_DIR) && cmake -DCMAKE_CXX_FLAGS="-Os -flto -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -fvisibility=hidden -Wno-stringop-overflow" -DCMAKE_BUILD_TYPE=MinSizeRel -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF ..
+else
+	cd $(BUILD_DIR) && cmake -DCMAKE_CXX_FLAGS="-Os -fno-exceptions -fno-rtti -fvisibility=hidden -Wno-stringop-overflow" -DCMAKE_BUILD_TYPE=MinSizeRel -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF ..
+endif
+	cd $(BUILD_DIR) && cmake --build . --target flatbuffers
+
+flatbuffers: $(BUILD_DIR)/libflatbuffers.a
+
+# Generate Flatbuffers binary schema (bfbs)
+$(POLICY_BFBS): $(SCHEMA_PATH)
+	flatc --binary --force-defaults --schema -o schema $(SCHEMA_PATH)
+
+# Generate Flatbuffers header file from binary schema
+$(POLICY_BFBS_HEADER): $(POLICY_BFBS)
+	xxd -i $< > $@
+
+# Build output binary
+$(OUT): $(SRC) flatbuffers $(CXXOPTS_HEADER)
+	mkdir -p $(MAKEFILE_DIR)/bin
+ifeq ($(shell uname), Linux)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SRC) $(LIBS) $(LDFLAGS) -o $@
+else
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SRC) $(LIBS) -o $@
+endif
+
+strip_binary:
+ifeq (, $(shell which $(STRIP)))
+	@echo "strip not found, skipping binary strip"
+else
+	$(STRIP) $(OUT)
+endif
+
+
+# Verify by unmarshalling compiled policy to JSON
+verify_json:
+ifndef BIN
+	$(error You must specify BIN=<path_to_bin_file>)
+endif
+	flatc --json --strict-json --raw-binary -o . $(SCHEMA_PATH) -- $(BIN)
+	@echo "Verification JSON written to $(BIN:.bin=.json)"
+
+clean:
+	rm -rf $(FLATBUFFERS_TARBALL) $(FLATBUFFERS_DIR) $(OUT) bin schema include *.bin *.json $(POLICY_BFBS_HEADER)
+
+fmt:
+	@echo "[i] Formatting source files..."
+	@clang-format -i $(FILES_TO_FORMAT)
+
+fmt-check:
+	@echo -e "[i] Files to format:\n$(FILES_TO_FORMAT)"
+	@clang-format --dry-run --Werror $(FILES_TO_FORMAT)

--- a/dd-compile-policy/flatbuffers.patch
+++ b/dd-compile-policy/flatbuffers.patch
@@ -1,0 +1,42 @@
+--- include/flatbuffers/base.h	2025-09-24 01:18:02.000000000 
++++ include/flatbuffers/base.h	2025-09-25 17:17:12.000000000 
+@@ -267,13 +267,14 @@
+ 
+ #ifndef FLATBUFFERS_LOCALE_INDEPENDENT
+   // Enable locale independent functions {strtof_l, strtod_l,strtoll_l,
+   // strtoull_l}.
+   #if (defined(_MSC_VER) && _MSC_VER >= 1800) || \
+       (defined(__ANDROID_API__) && __ANDROID_API__>= 21) || \
+-      (defined(_XOPEN_VERSION) && (_XOPEN_VERSION >= 700)) && \
++			(defined(_XOPEN_VERSION) && (_XOPEN_VERSION >= 700) && \
++				defined(__GLIBC__) && !defined(__UCLIBC__)) && \
+         (!defined(__Fuchsia__) && !defined(__ANDROID_API__))
+     #define FLATBUFFERS_LOCALE_INDEPENDENT 1
+   #else
+     #define FLATBUFFERS_LOCALE_INDEPENDENT 0
+   #endif
+ #endif  // !FLATBUFFERS_LOCALE_INDEPENDENT
+--- src/idl_parser.cpp	2025-09-24 01:18:02.000000000 
++++ src/idl_parser.cpp	2025-09-25 17:37:40.000000000 
+@@ -1993,14 +1993,19 @@
+       auto enum_def_str = word.substr(0, dot);
+       const auto enum_def = LookupEnum(enum_def_str);
+       if (!enum_def) return Error("unknown enum: " + enum_def_str);
+       auto enum_val_str = word.substr(dot + 1);
+       ev = enum_def->Lookup(enum_val_str);
+     }
+-    if (!ev) return Error("unknown enum value: " + word);
+-    u64 |= ev->GetAsUInt64();
++    // if (!ev) return Error("unknown enum value: " + word);
++    // fall to defaults
++    if (!ev) {
++      u64 = 0;
++    } else {
++      u64 |= ev->GetAsUInt64();
++    }
+   }
+   *result = IsUnsigned(base_type) ? NumToString(u64)
+                                   : NumToString(static_cast<int64_t>(u64));
+   return NoError();
+ }
+ 

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -1,0 +1,78 @@
+#include <flatbuffers/flatbuffers.h>
+#include <flatbuffers/idl.h>
+#include <flatbuffers/minireflect.h>
+#include <flatbuffers/reflection.h>
+#include <flatbuffers/util.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "cxxopts.hpp"
+#include "policy_schema_bfbs.h" // Contains `schema_policy_bfbs` and `schema_policy_bfbs_len`
+
+int main(int argc, char *argv[]) {
+  std::string json_str;
+  std::string json_file;
+  std::string output_path;
+
+  // Parse command line arguments
+  cxxopts::Options options("dd-compile-policy",
+                           "Compile policy JSON to FlatBuffer binary");
+
+  options.add_options()("input-json", "Input JSON file path",
+                        cxxopts::value<std::string>())(
+      "output", "Output binary file path",
+      cxxopts::value<std::string>())("h,help", "Print usage");
+
+  auto result = options.parse(argc, argv);
+
+  if (result.count("help")) {
+    std::cout << options.help() << std::endl;
+    return EXIT_SUCCESS;
+  }
+
+  if (!result.count("input-json") || !result.count("output")) {
+    std::cerr << "Error: Both --input-json and --output are required."
+              << std::endl;
+    std::cerr << options.help() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  json_file = result["input-json"].as<std::string>();
+  output_path = result["output"].as<std::string>();
+
+  flatbuffers::Parser parser;
+
+  // Load binary schema (.bfbs)
+  if (!parser.Deserialize(reinterpret_cast<const uint8_t *>(schema_policy_bfbs),
+                          schema_policy_bfbs_len)) {
+    std::cerr << "Failed to parse binary schema\n";
+    return EXIT_FAILURE;
+  }
+
+  std::cout << json_file << std::endl;
+  bool ok = flatbuffers::LoadFile(json_file.c_str(), false, &json_str);
+  if (!ok) {
+    std::cerr << "failed to open file " << json_file << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Parse JSON string
+  if (!parser.ParseJson(json_str.c_str())) {
+    std::cerr << "Failed to parse JSON: " << parser.error_ << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Write FlatBuffer binary
+  std::ofstream out(output_path, std::ios::binary);
+  if (!out) {
+    std::cerr << "Failed to open output file: " << output_path << std::endl;
+    return EXIT_FAILURE;
+  }
+  out.write(reinterpret_cast<const char *>(parser.builder_.GetBufferPointer()),
+            parser.builder_.GetSize());
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Description

Taken from https://github.com/DataDog/auto_inject/pull/730

Adds a `dd-policy-compile` tool written in C++ to compile policies into FlatBuffers' binary files.
Today the interface is `dd-compile-policy --input-json <json-file-path> --output <output.bin>` but it may change in the next few commits according to review.

## How Has This Been Tested?

Manual tests:
- In `~/dd/auto_inject`, hop into a Linux container with `docker run --rm -it -v $(pwd):/home docker.io/library/injector-build-container:1 /bin/bash`; then `cd /home` 
- Build the new binary with `make -C policies/dd-compile-policy build`
- Build examples with `make -C policies/c examples` (if only `basic-reader` builds it's enough)
- Create a policy with `./policies/dd-compile-policy/bin/dd-compile-policy --input-json '{"policies":[{"rules":{"node_type":"EvaluatorNode","node":{"eval_type":"StrEvaluator","eval":{"id":"RUNTIME_LANGUAGE","cmp":"CMP_EXACT","value":"jvm"}}},"actions":[{"action":"INJECT_ALLOW","values":[]}]}]}' --output ./policies/dd-compile-policy/policy.bin`
- Verify that the generated binary is as expected with `make -C policies/dd-compile-policy verify_json BIN=./policy.bin && cat ./policies/dd-compile-policy/policy.json`
- Evaluate the policy with `./policies/c/examples/basic-reader ./policies/dd-compile-policy/policy.bin`, it should have exit code 0 & `Result: true` in the output.

## Additional Notes

### Why C++?

C++ is the language https://github.com/google/flatbuffers is built in ; thus it makes its core easy to import! Besides C++ easily deserialises JSON without require a struct or casts like Go does.

### How big is the binary?

The binary is ~9.7MB because it is statically linked.

### How does this work ?

I didn't want to build a full flatbuffers object from the builder functions every time, especially as this would mean (manually) re-writing significantly the code on each schema change. Instead, we compile the schema and embed the compiled version as a buffer directly in the binary. This keeps the code simple, and doesn't significantly increase the binary size as the compiled schema is a few kilobytes only.