### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,69 @@ name: Release
 on: [workflow_dispatch]
 
 jobs:
-  dummy:
+  build-and-package-linux:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     container:
       image: datadog/docker-library:dd-policy-engine-10949a6
+    environment:
+      name: dev-env
+    permissions:
+      contents: read
+      packages: read
+    env:
+      IN_DOCKER: "true"
     steps:
-      - run: echo "Hello, World!"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Configure
+        run: cmake -B build --preset clang-release .
+      - name: Build
+        run: cmake --build build --target dd-policy-engine.static-lib -j
+      - name: Install
+        run: cmake --install build --prefix=dist
+      - name: Export library
+        uses: actions/upload-artifact@v4
+        with:
+          name: libpolicies-linux
+          path: dist
+
+  build-and-package-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["x64", "x86"]
+    runs-on: windows-2022
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: powershell
+    environment:
+      name: dev-env
+    permissions:
+      contents: read
+      packages: read
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ matrix.arch }}
+      - name: Install Dependency Manager (scoop)
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+          Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+      - name: Install Dependencies
+        run: scoop install main/cmake@4.0.1
+      - name: Build
+        run: |
+          cmake -B build --preset msvc-release .
+          cmake --build build --target dd-policy-engine.static-lib -j
+          cmake --install build --prefix=dist
+      - name: Export library
+        uses: actions/upload-artifact@v4
+        with:
+          name: libpolicies-win-${{ matrix.arch }}
+          path: dist

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,6 +49,17 @@
       }
     },
     {
+      "name": "msvc-release",
+      "displayName": "Windows Release",
+      "inherits": "msvc-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "environment": {
+        "ADDITIONAL_C_FLAGS": "/std:c17"
+      }
+    },
+    {
       "name": "clang-dev",
       "displayName": "Clang Development",
       "inherits": "clang-base",
@@ -96,6 +107,17 @@
       },
       "environment": {
         "ADDITIONAL_C_FLAGS": "-std=c23 -fsanitize=fuzzer,address"
+      }
+    },
+    {
+      "name": "clang-release",
+      "displayName": "Clang Release",
+      "inherits": "clang-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "environment": {
+        "ADDITIONAL_C_FLAGS": "-std=c23"
       }
     }
   ]


### PR DESCRIPTION


Changes:
  - Add two new presets `msvc-release` and `clang-release`.
