### PR TITLE
Validate requirements.json input for dd-requirements-converter and require version 1

### DIFF
--- a/go/cmd/dd-requirements-converter/main.go
+++ b/go/cmd/dd-requirements-converter/main.go
@@ -19,7 +19,7 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
-// parseRequirementsJSON decodes requirements document bytes the same way as the CLI: rejects
+// parseRequirementsJSON decodes the raw bytes for requirements.json the same way as the CLI: rejects
 // empty/whitespace-only input and invalid JSON before conversion.
 func parseRequirementsJSON(raw []byte) (converter.JSONRequirements, error) {
 	var req converter.JSONRequirements

--- a/go/cmd/dd-requirements-converter/main.go
+++ b/go/cmd/dd-requirements-converter/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -17,6 +18,22 @@ import (
 
 	flatbuffers "github.com/google/flatbuffers/go"
 )
+
+// parseRequirementsJSON decodes requirements document bytes the same way as the CLI: rejects
+// empty/whitespace-only input and invalid JSON before conversion.
+func parseRequirementsJSON(raw []byte) (converter.JSONRequirements, error) {
+	var req converter.JSONRequirements
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return req, fmt.Errorf("requirements input is empty or whitespace-only")
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return req, fmt.Errorf("invalid requirements JSON: %w", err)
+	}
+	if req.Version != 1 {
+		return req, fmt.Errorf("requirements.bin version must be 1, got %d", req.Version)
+	}
+	return req, nil
+}
 
 func main() {
 	inputFile := flag.String("input-file", "", "Input JSON file path (required)")
@@ -35,14 +52,14 @@ func main() {
 	}
 	defer file.Close()
 
-	bytes, err := io.ReadAll(file)
+	raw, err := io.ReadAll(file)
 	if err != nil {
-		log.Fatalf("Failed to read input file: %v", err)
+		log.Fatalf("failed to read input file %s: %v", *inputFile, err)
 	}
 
-	var requirements converter.JSONRequirements
-	if err := json.Unmarshal(bytes, &requirements); err != nil {
-		log.Fatalf("Failed to parse JSON: %v", err)
+	requirements, err := parseRequirementsJSON(raw)
+	if err != nil {
+		log.Fatalf("invalid requirements in %s: %v", *inputFile, err)
 	}
 
 	builder := flatbuffers.NewBuilder(1024)

--- a/go/cmd/dd-requirements-converter/main.go
+++ b/go/cmd/dd-requirements-converter/main.go
@@ -29,10 +29,14 @@ func parseRequirementsJSON(raw []byte) (converter.JSONRequirements, error) {
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return req, fmt.Errorf("invalid requirements JSON: %w", err)
 	}
-	if req.Version != 1 {
-		return req, fmt.Errorf("requirements.bin version must be 1, got %d", req.Version)
-	}
 	return req, nil
+}
+
+func validateRequirementsVersion(req converter.JSONRequirements) error {
+	if req.Version != 1 {
+		return fmt.Errorf("requirements.bin version must be 1, got %d", req.Version)
+	}
+	return nil
 }
 
 func main() {
@@ -59,6 +63,9 @@ func main() {
 
 	requirements, err := parseRequirementsJSON(raw)
 	if err != nil {
+		log.Fatalf("invalid requirements in %s: %v", *inputFile, err)
+	}
+	if err := validateRequirementsVersion(requirements); err != nil {
 		log.Fatalf("invalid requirements in %s: %v", *inputFile, err)
 	}
 

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -534,6 +534,76 @@ func TestJSONDeny_ConvertToWLS(t *testing.T) {
 	}
 }
 
+func TestParseRequirementsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "incomplete object",
+			input:   "{",
+			wantErr: true,
+		},
+		{
+			name:    "lone closing brace",
+			input:   "}",
+			wantErr: true,
+		},
+		{
+			name:    "empty object missing version",
+			input:   "{}",
+			wantErr: true,
+		},
+		{
+			name:    "version zero",
+			input:   `{"version":0}`,
+			wantErr: true,
+		},
+		{
+			name:    "version two",
+			input:   `{"version":2}`,
+			wantErr: true,
+		},
+		{
+			name:    "version must be number",
+			input:   `{ "version": "not a number" }`,
+			wantErr: true,
+		},
+		{
+			name:    "version one minimal",
+			input:   `{"version":1}`,
+			wantErr: false,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   \n\t  ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseRequirementsJSON([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected parse error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -542,12 +612,13 @@ func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 	}{
 		{
 			name:              "empty requirements",
-			inputJSON:         `{}`,
+			inputJSON:         `{"version":1}`,
 			expectedRuleCount: 0,
 		},
 		{
 			name: "glibc + musl + deny combined",
 			inputJSON: `{
+				"version": 1,
 				"deny": [{"os": "windows", "description": "no windows"}],
 				"native_deps": {
 					"glibc": [{"arch": "x64", "supported": true, "min": "2.17"}],

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -556,9 +556,14 @@ func TestParseRequirementsJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty object missing version",
+			name:    "empty object version zero",
 			input:   "{}",
 			wantErr: true,
+		},
+		{
+			name:    "version one only",
+			input:   `{"version":1}`,
+			wantErr: false,
 		},
 		{
 			name:    "version zero",
@@ -576,8 +581,8 @@ func TestParseRequirementsJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "version one minimal",
-			input:   `{"version":1}`,
+			name:    "version one with empty deny and native_deps",
+			input:   `{"version":1,"deny":[],"native_deps":{"glibc":[],"musl":[]}}`,
 			wantErr: false,
 		},
 		{
@@ -612,13 +617,12 @@ func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 	}{
 		{
 			name:              "empty requirements",
-			inputJSON:         `{"version":1}`,
+			inputJSON:         `{}`,
 			expectedRuleCount: 0,
 		},
 		{
 			name: "glibc + musl + deny combined",
 			inputJSON: `{
-				"version": 1,
 				"deny": [{"os": "windows", "description": "no windows"}],
 				"native_deps": {
 					"glibc": [{"arch": "x64", "supported": true, "min": "2.17"}],

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -556,7 +556,7 @@ func TestParseRequirementsJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty object version not one",
+			name:    "empty object",
 			input:   "{}",
 			wantErr: false,
 		},

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -556,29 +556,9 @@ func TestParseRequirementsJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty object version zero",
+			name:    "empty object version not one",
 			input:   "{}",
-			wantErr: true,
-		},
-		{
-			name:    "version one only",
-			input:   `{"version":1}`,
 			wantErr: false,
-		},
-		{
-			name:    "version zero",
-			input:   `{"version":0}`,
-			wantErr: true,
-		},
-		{
-			name:    "version two",
-			input:   `{"version":2}`,
-			wantErr: true,
-		},
-		{
-			name:    "version must be number",
-			input:   `{ "version": "not a number" }`,
-			wantErr: true,
 		},
 		{
 			name:    "version one with empty deny and native_deps",
@@ -613,16 +593,44 @@ func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 	tests := []struct {
 		name              string
 		inputJSON         string
-		expectedRuleCount int // number of rules ORed together in the single policy
+		wantUnmarshalErr  bool
+		wantVersionErr    bool
+		expectedRuleCount int // when conversion runs: rules ORed together in the single policy
 	}{
 		{
+			name:              "version one only",
+			inputJSON:         `{"version":1}`,
+			expectedRuleCount: 0,
+		},
+		{
+			name:           "version zero",
+			inputJSON:      `{"version":0}`,
+			wantVersionErr: true,
+		},
+		{
+			name:           "version two",
+			inputJSON:      `{"version":2}`,
+			wantVersionErr: true,
+		},
+		{
+			name:             "version must be number",
+			inputJSON:        `{ "version": "not a number" }`,
+			wantUnmarshalErr: true,
+		},
+		{
+			name:           "empty object missing version",
+			inputJSON:      `{}`,
+			wantVersionErr: true,
+		},
+		{
 			name:              "empty requirements",
-			inputJSON:         `{}`,
+			inputJSON:         `{"version":1,"deny":[],"native_deps":{"glibc":[],"musl":[]}}`,
 			expectedRuleCount: 0,
 		},
 		{
 			name: "glibc + musl + deny combined",
 			inputJSON: `{
+				"version": 1,
 				"deny": [{"os": "windows", "description": "no windows"}],
 				"native_deps": {
 					"glibc": [{"arch": "x64", "supported": true, "min": "2.17"}],
@@ -636,8 +644,26 @@ func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var req converter.JSONRequirements
-			if err := json.Unmarshal([]byte(tt.inputJSON), &req); err != nil {
-				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			err := json.Unmarshal([]byte(tt.inputJSON), &req)
+			if tt.wantUnmarshalErr {
+				if err == nil {
+					t.Fatal("expected JSON unmarshal error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshal JSON: %v", err)
+			}
+
+			err = validateRequirementsVersion(req)
+			if tt.wantVersionErr {
+				if err == nil {
+					t.Fatal("expected validateRequirementsVersion error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateRequirementsVersion: %v", err)
 			}
 
 			builder := flatbuffers.NewBuilder(1024)

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -624,7 +624,12 @@ func TestJSONRequirements_ConvertToWLS(t *testing.T) {
 		},
 		{
 			name:              "empty requirements",
-			inputJSON:         `{"version":1,"deny":[],"native_deps":{"glibc":[],"musl":[]}}`,
+			inputJSON:         `{}`,
+			wantVersionErr: true,
+		},
+		{
+			name:              "no native_deps and no deny",
+			inputJSON:         `{"version":1,"native_deps":{},"deny":[]}`,
 			expectedRuleCount: 0,
 		},
 		{


### PR DESCRIPTION
Update `dd-requirements-converter` so `requirements.json` is validated up front. Empty input is rejected, JSON must parse, and version must be 1 before converting to WLS (to stay consistent with how the Go code in auto_inject parsed requirements.json [here](https://github.com/DataDog/auto_inject/blob/main/preload_go/libraryrequirements/requirements.go#L99-L102)). Tests cover invalid JSON and version handling. 

Moved these [invalid JSON test cases](https://github.com/DataDog/auto_inject/blob/bd6ea2aa10e456db91c5989ac0ab781fdd414d48/test/test_injector.py#L815-L831) from `auto_inject` repo to here.

[INPLAT-1034](https://datadoghq.atlassian.net/browse/INPLAT-1034)

[INPLAT-1034]: https://datadoghq.atlassian.net/browse/INPLAT-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ