### PR TITLE
Expose matched rule description after policy evaluation

### DIFF
--- a/c/include/dd/policies/eval_ctx.h
+++ b/c/include/dd/policies/eval_ctx.h
@@ -161,6 +161,21 @@ unsigned long plcs_eval_ctx_get_unumeric_param(plcs_numeric_evaluators id);
 plcs_action_function_ptr plcs_eval_ctx_get_action(plcs_actions ix);
 
 /**
+ * @brief Returns the human-readable description of the rule that matched during
+ * the most recent policy evaluation, or NULL if the policy did not match.
+ *
+ * For policies that bundle many rules under a top-level OR (e.g.
+ * dd-requirements-converter output) this is the description of the specific
+ * rule that fired (e.g. "Ignore the npm CLI (symlink)"). For single-rule
+ * policies (e.g. json_to_hardcoded_fb_policies) this is the policy's own description field.
+ *
+ * @note Reset to NULL at the start of each evaluate_policy call. The returned
+ * pointer is owned by the FlatBuffer passed to plcs_evaluate_buffer and is
+ * only valid until that buffer is freed.
+ */
+const char *plcs_eval_ctx_get_matched_description(void);
+
+/**
  * @brief An accessor for the last error
  * @return the last error as a plcs_errors enum, NOTE: This will RESET the error!
  */

--- a/c/src/debugger/basic-debugger.c
+++ b/c/src/debugger/basic-debugger.c
@@ -73,7 +73,12 @@ size_t print_node_composite(dd_ns(CompositeNode_table_t) node) {
   dd_ns(NodeTypeWrapper_vec_t) children = dd_ns(CompositeNode_children)(node);
   size_t children_len = children ? dd_ns(NodeTypeWrapper_vec_len)(children) : 0;
   dd_wls_BoolOperation_enum_t oper = dd_ns(CompositeNode_op)(node);
-  printf("(%c%c)\n", get_oper_char(oper), get_oper_char(oper));
+  const char *desc = dd_ns(CompositeNode_description)(node);
+  if (desc && desc[0] != '\0') {
+    printf("(%c%c)[%s]\n", get_oper_char(oper), get_oper_char(oper), desc);
+  } else {
+    printf("(%c%c)\n", get_oper_char(oper), get_oper_char(oper));
+  }
 
   return children_len;  // indicate success
 }

--- a/c/src/eval_ctx.c
+++ b/c/src/eval_ctx.c
@@ -208,6 +208,14 @@ plcs_errors plcs_eval_ctx_get_unum_eval_error(plcs_numeric_evaluators ix) {
   return PLCS_EIX_OVERFLOW;
 }
 
+const char *plcs_eval_ctx_get_matched_description(void) {
+  return ctx.matched_description;
+}
+
+void plcs_eval_ctx_set_matched_description(const char *desc) {
+  ctx.matched_description = desc;
+}
+
 plcs_errors plcs_eval_ctx_peek_last_error(void) {
   return ctx.error;
 }
@@ -244,6 +252,7 @@ void plcs_eval_ctx_reset(void) {
   }
 
   ctx.error = PLCS_ESUCCESS;
+  ctx.matched_description = NULL;
 }
 
 plcs_errors plcs_eval_ctx_init(void) {

--- a/c/src/eval_ctx.c
+++ b/c/src/eval_ctx.c
@@ -12,8 +12,12 @@
 #include "eval_ctx.h"
 
 #include <stdbool.h>
+#include <stdio.h>
 
 static plcs_eval_ctx ctx;
+// Buffer for combined "rule (condition)" matched descriptions. Sized to hold
+// typical human-readable rule + evaluator descriptions with room to spare.
+static char matched_description_buf[512];
 static bool plcs_eval_ctx_initialized = false;
 
 plcs_errors
@@ -216,6 +220,19 @@ void plcs_eval_ctx_set_matched_description(const char *desc) {
   ctx.matched_description = desc;
 }
 
+void plcs_eval_ctx_set_matched_description_combined(const char *rule_desc, const char *eval_desc) {
+  snprintf(matched_description_buf, sizeof(matched_description_buf), "%s (%s)", rule_desc, eval_desc);
+  ctx.matched_description = matched_description_buf;
+}
+
+void plcs_eval_ctx_set_matched_evaluator_description(const char *desc) {
+  ctx.matched_evaluator_description = desc;
+}
+
+const char *plcs_eval_ctx_get_matched_evaluator_description(void) {
+  return ctx.matched_evaluator_description;
+}
+
 plcs_errors plcs_eval_ctx_peek_last_error(void) {
   return ctx.error;
 }
@@ -253,6 +270,7 @@ void plcs_eval_ctx_reset(void) {
 
   ctx.error = PLCS_ESUCCESS;
   ctx.matched_description = NULL;
+  ctx.matched_evaluator_description = NULL;
 }
 
 plcs_errors plcs_eval_ctx_init(void) {

--- a/c/src/eval_ctx.h
+++ b/c/src/eval_ctx.h
@@ -111,6 +111,27 @@ typedef struct plcs_eval_ctx {
   /**< TODO: consider implementing this as a stack to preserve history of errors */
   plcs_errors error;
 
+  /**
+   * @brief Description of the top-level OR child that returned TRUE during the
+   * most recent policy evaluation. NULL if no OR-level match occurred. Set by
+   * composite_evaluator at depth 0; read via plcs_eval_ctx_get_matched_description().
+   *
+   * For dd-requirements-converter policies, the tree looks something like:
+   *
+   *   Policy("All requirements")
+   *   └── (||)                          <- depth 0, root; composite_evaluator checks depth == 0
+   *       ├── (&&) "Ignore npm CLI"     <- top-level OR child; description captured on match
+   *       │   └── [PROCESS_ARGV_1 ~= *\/npm]
+   *       ├── (&&) "Ignore yarn"
+   *       │   └── [PROCESS_ARGV_1 ~= *\/yarn]
+   *       └── (&&) "glibc arm >= 2.24"
+   *           ├── [MACHINE_ARCHITECTURE == arm]
+   *           ├── [LIBC_FLAVOR == glibc]
+   *           └── (||)                  <- depth 2; never triggers capture
+   *               └── ...
+   */
+  const char *matched_description;
+
 } plcs_eval_ctx;
 
 /**
@@ -146,3 +167,15 @@ void plcs_eval_ctx_set_num_eval_error(plcs_numeric_evaluators id, plcs_errors er
  * @param error plcs_errors enum
  */
 void plcs_eval_ctx_set_unum_eval_error(plcs_numeric_evaluators ix, plcs_errors error);
+
+/**
+ * @brief Records the description of the matched OR child for the current policy evaluation.
+ *
+ * Internal — called by composite_evaluator when a top-level OR child returns TRUE.
+ * The pointer is stored verbatim (no copy) and must remain valid until the next
+ * plcs_eval_ctx_reset() or plcs_evaluate_buffer() call — in practice, a string
+ * inside the FlatBuffer being evaluated.
+ *
+ * @param desc Description string, or NULL to clear.
+ */
+void plcs_eval_ctx_set_matched_description(const char *desc);

--- a/c/src/eval_ctx.h
+++ b/c/src/eval_ctx.h
@@ -132,6 +132,16 @@ typedef struct plcs_eval_ctx {
    */
   const char *matched_description;
 
+  /**
+   * @brief Description of the most recent EvaluatorNode that returned TRUE.
+   * Overwritten on each TRUE leaf result during evaluation. Used by
+   * capture_matched_description to append specifics to a composite rule
+   * description (e.g. "Ignore the yarn CLI" + "Argument matching: *\/yarn.js"
+   * → "Ignore the yarn CLI (Argument matching: *\/yarn.js)").
+   * Reset to NULL at the start of each evaluate_policy call.
+   */
+  const char *matched_evaluator_description;
+
 } plcs_eval_ctx;
 
 /**
@@ -179,3 +189,26 @@ void plcs_eval_ctx_set_unum_eval_error(plcs_numeric_evaluators ix, plcs_errors e
  * @param desc Description string, or NULL to clear.
  */
 void plcs_eval_ctx_set_matched_description(const char *desc);
+
+/**
+ * @brief Combines a composite node description with the most-recently-matched
+ * evaluator description and stores the result as the matched description.
+ *
+ * Formats as "<rule_desc> (<eval_desc>)", e.g.
+ * "Ignore the yarn CLI (Argument matching: *\/yarn.js)".
+ * The result is written into a static internal buffer valid until the next
+ * evaluate_policy call.
+ */
+void plcs_eval_ctx_set_matched_description_combined(const char *rule_desc, const char *eval_desc);
+
+/**
+ * @brief Records the description of the most recent EvaluatorNode that returned TRUE.
+ * Called by node_evaluator on a TRUE result.
+ */
+void plcs_eval_ctx_set_matched_evaluator_description(const char *desc);
+
+/**
+ * @brief Returns the description of the most recent EvaluatorNode that returned TRUE,
+ * or NULL if none has fired yet in this evaluation cycle.
+ */
+const char *plcs_eval_ctx_get_matched_evaluator_description(void);

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -168,6 +168,16 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
   }
 }
 
+static inline void capture_matched_description(dd_ns(NodeTypeWrapper_table_t) wrapper) {
+  if (!wrapper)
+    return;
+  if (dd_ns(NodeTypeWrapper_node_type)(wrapper) != dd_ns(NodeType_CompositeNode))
+    return;
+  dd_ns(CompositeNode_table_t) c = dd_ns(NodeTypeWrapper_node)(wrapper);
+  if (c)
+    plcs_eval_ctx_set_matched_description(dd_ns(CompositeNode_description)(c));
+}
+
 plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth) {
   if (!node) {
     return PLCS_EVAL_RESULT_ABSTAIN;
@@ -209,6 +219,9 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
 
     // short circuit
     if (oper == dd_ns(BoolOperation_BOOL_OR) && res == PLCS_EVAL_RESULT_TRUE) {
+      if (depth == 0) {
+        capture_matched_description(dd_ns(NodeTypeWrapper_vec_at)(children, ix));
+      }
       return res;
     }
 
@@ -286,8 +299,16 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   // extract rules
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
 
+  plcs_eval_ctx_set_matched_description(NULL);
+
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
   plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
+
+  // For policies whose root is not a top-level OR (json_to_hardcoded_fb_policies, which use an AND root), the depth-0
+  // capture in composite_evaluator never fires. Fall back to the policy's own description field.
+  if (eval_res == PLCS_EVAL_RESULT_TRUE && plcs_eval_ctx_get_matched_description() == NULL) {
+    plcs_eval_ctx_set_matched_description(dd_ns(Policy_description)(policy));
+  }
 
   // perform actions given evaluation result
   return perform_actions(eval_res, actions);

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -91,25 +91,34 @@ plcs_evaluation_result evaluate_unumeric(dd_ns(UNumEvaluator_table_t) eval_unum,
 }
 
 plcs_evaluation_result node_evaluator(dd_ns(EvaluatorNode_table_t) node) {
-  plcs_evaluation_result result = PLCS_EVAL_RESULT_ABSTAIN;
   if (!node) {
-    return result;  // log error?
+    return PLCS_EVAL_RESULT_ABSTAIN;
   }
 
   dd_ns(EvaluatorType_union_t) evaluator = dd_ns(EvaluatorNode_eval_union)(node);
+  plcs_evaluation_result result = PLCS_EVAL_RESULT_ABSTAIN;
 
   switch (evaluator.type) {
     case dd_ns(EvaluatorType_StrEvaluator):
-      return evaluate_string(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      result = evaluate_string(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      break;
 
     case dd_ns(EvaluatorType_NumEvaluator):
-      return evaluate_numeric(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      result = evaluate_numeric(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      break;
 
     case dd_ns(EvaluatorType_UNumEvaluator):
-      return evaluate_unumeric(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      result = evaluate_unumeric(evaluator.value, dd_ns(EvaluatorNode_description)(node));
+      break;
+
+    default:
+      plcs_eval_ctx_set_error(PLCS_EUNKNOWN_EVAL_IX);
+      return result;
   }
 
-  plcs_eval_ctx_set_error(PLCS_EUNKNOWN_EVAL_IX);
+  if (result == PLCS_EVAL_RESULT_TRUE) {
+    plcs_eval_ctx_set_matched_evaluator_description(dd_ns(EvaluatorNode_description)(node));
+  }
   return result;
 }
 
@@ -169,13 +178,28 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
 }
 
 static inline void capture_matched_description(dd_ns(NodeTypeWrapper_table_t) wrapper) {
-  if (!wrapper)
-    return;
-  if (dd_ns(NodeTypeWrapper_node_type)(wrapper) != dd_ns(NodeType_CompositeNode))
-    return;
-  dd_ns(CompositeNode_table_t) c = dd_ns(NodeTypeWrapper_node)(wrapper);
-  if (c)
-    plcs_eval_ctx_set_matched_description(dd_ns(CompositeNode_description)(c));
+  if (!wrapper) return;
+  switch (dd_ns(NodeTypeWrapper_node_type)(wrapper)) {
+    case dd_ns(NodeType_CompositeNode): {
+      dd_ns(CompositeNode_table_t) c = dd_ns(NodeTypeWrapper_node)(wrapper);
+      if (!c) break;
+      const char *desc = dd_ns(CompositeNode_description)(c);
+      const char *eval_desc = plcs_eval_ctx_get_matched_evaluator_description();
+      if (desc && eval_desc && eval_desc[0] != '\0') {
+        plcs_eval_ctx_set_matched_description_combined(desc, eval_desc);
+      } else {
+        plcs_eval_ctx_set_matched_description(desc);
+      }
+      break;
+    }
+    case dd_ns(NodeType_EvaluatorNode): {
+      dd_ns(EvaluatorNode_table_t) e = dd_ns(NodeTypeWrapper_node)(wrapper);
+      if (e) plcs_eval_ctx_set_matched_description(dd_ns(EvaluatorNode_description)(e));
+      break;
+    }
+    default:
+      break;
+  }
 }
 
 plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth) {
@@ -219,7 +243,11 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
 
     // short circuit
     if (oper == dd_ns(BoolOperation_BOOL_OR) && res == PLCS_EVAL_RESULT_TRUE) {
-      if (depth == 0) {
+      // Capture at depth 0 (dd-requirements-converter: top-level OR over AND rules) and
+      // depth 1 (hardcoded runtime-specific policies: AND root wrapping an OR over conditions).
+      // dd-requirements-converter rules are AND nodes at depth 1, so their short-circuits are
+      // FALSE returns that never reach here — no interference between the two cases.
+      if (depth <= 1) {
         capture_matched_description(dd_ns(NodeTypeWrapper_vec_at)(children, ix));
       }
       return res;
@@ -300,13 +328,14 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
 
   plcs_eval_ctx_set_matched_description(NULL);
+  plcs_eval_ctx_set_matched_evaluator_description(NULL);
 
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
   plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
 
   // For policies whose root is not a top-level OR (json_to_hardcoded_fb_policies, which use an AND root), the depth-0
   // capture in composite_evaluator never fires. Fall back to the policy's own description field.
-  if (eval_res == PLCS_EVAL_RESULT_TRUE && plcs_eval_ctx_get_matched_description() == NULL) {
+  if (eval_res == PLCS_EVAL_RESULT_TRUE && (plcs_eval_ctx_get_matched_description() == NULL || plcs_eval_ctx_get_matched_description()[0] == '\0')) {
     plcs_eval_ctx_set_matched_description(dd_ns(Policy_description)(policy));
   }
 

--- a/go/cmd/dd-requirements-converter/converter/deny.go
+++ b/go/cmd/dd-requirements-converter/converter/deny.go
@@ -100,14 +100,6 @@ func (d JSONDeny) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffers.UOffse
 		nodes = append(nodes, schema.NodeTypeWrapperCreate(builder, andNode, wls.NodeTypeCompositeNode))
 	}
 
-	var root flatbuffers.UOffsetT
-	// if there is only one node, use it directly (it's already a NodeTypeWrapper)
-	if len(nodes) == 1 {
-		root = nodes[0]
-	} else if len(nodes) > 1 {
-		andNode := schema.CompositeNodeCreate(builder, wls.BoolOperationBOOL_AND, d.Description, nodes)
-		root = schema.NodeTypeWrapperCreate(builder, andNode, wls.NodeTypeCompositeNode)
-	}
-
-	return root, nil
+	andNode := schema.CompositeNodeCreate(builder, wls.BoolOperationBOOL_AND, d.Description, nodes)
+	return schema.NodeTypeWrapperCreate(builder, andNode, wls.NodeTypeCompositeNode), nil
 }

--- a/go/cmd/dd-requirements-converter/main_test.go
+++ b/go/cmd/dd-requirements-converter/main_test.go
@@ -456,27 +456,27 @@ func TestJSONDeny_ConvertToWLS(t *testing.T) {
 	}{
 		{
 			// OS only: {"os": "linux"}
-			// → StrEvaluator(OS, EXACT, "linux")
+			// → AND(description, [StrEvaluator(OS, EXACT, "linux")])
 			name:         "os only",
 			inputJSON:    `{"os": "linux", "description": "deny linux"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsOS, "linux"),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsOS, "linux")),
 		},
 		{
 			// Single cmd: {"cmds": ["/usr/bin/curl"]}
-			// → StrEvaluator(PROCESS_EXE_FULL_PATH, EXACT, "/usr/bin/curl")
+			// → AND(description, [StrEvaluator(PROCESS_EXE_FULL_PATH, EXACT, "/usr/bin/curl")])
 			name:         "single exact command",
 			inputJSON:    `{"cmds": ["/usr/bin/curl"], "description": "deny curl"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_EXE_FULL_PATH, "/usr/bin/curl"),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_EXE_FULL_PATH, "/usr/bin/curl")),
 		},
 		{
 			// Multiple cmds: {"cmds": ["/usr/bin/curl", "/usr/bin/wget"]}
-			// → OR(cmd1, cmd2)
+			// → AND(description, [OR(cmd1, cmd2)])
 			name:      "multiple commands - OR",
 			inputJSON: `{"cmds": ["/usr/bin/curl", "/usr/bin/wget"], "description": "deny download tools"}`,
-			expectedRoot: orNode(
+			expectedRoot: andNode(orNode(
 				strEval(wls.StringEvaluatorsPROCESS_EXE_FULL_PATH, "/usr/bin/curl"),
 				strEval(wls.StringEvaluatorsPROCESS_EXE_FULL_PATH, "/usr/bin/wget"),
-			),
+			)),
 		},
 		{
 			// OS + cmd: {"os": "linux", "cmds": ["/bin/rm"]}
@@ -490,33 +490,33 @@ func TestJSONDeny_ConvertToWLS(t *testing.T) {
 		},
 		{
 			// Single env var: {"envars": {"DEBUG": "1"}}
-			// → StrEvaluator(PROCESS_ENVAR, EXACT, "DEBUG=1")
+			// → AND(description, [StrEvaluator(PROCESS_ENVAR, EXACT, "DEBUG=1")])
 			name:         "single environment variable",
 			inputJSON:    `{"envars": {"DEBUG": "1"}, "description": "deny debug mode"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_ENVAR, "DEBUG=1"),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_ENVAR, "DEBUG=1")),
 		},
 		{
 			name:         "environment variable wildcard asterisk in value",
 			inputJSON:    `{"envars": {"PATH": "/usr/*/bin"}, "description": "deny path pattern"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_ENVAR, "PATH=/usr/*/bin", wls.CmpTypeSTRCMP_WILDCARD),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_ENVAR, "PATH=/usr/*/bin", wls.CmpTypeSTRCMP_WILDCARD)),
 		},
 		{
 			name:         "environment variable wildcard question in value",
 			inputJSON:    `{"envars": {"TERM": "xterm-?56color"}, "description": "deny term pattern"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_ENVAR, "TERM=xterm-?56color", wls.CmpTypeSTRCMP_WILDCARD),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_ENVAR, "TERM=xterm-?56color", wls.CmpTypeSTRCMP_WILDCARD)),
 		},
 		{
 			// JSON null value → KEY=*? + CMP_WILDCARD ("any non-empty value" for KEY=)
 			name:         "environment variable null value matches non-empty only",
 			inputJSON:    `{"envars": {"FOO": null}, "description": "deny when FOO set to any non-empty value"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_ENVAR, "FOO=*?", wls.CmpTypeSTRCMP_WILDCARD),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_ENVAR, "FOO=*?", wls.CmpTypeSTRCMP_WILDCARD)),
 		},
 		{
 			// Single arg: {"args": [{"args": ["-rf"]}]}
-			// → StrEvaluator(PROCESS_ARGV, EXACT, "-rf")
+			// → AND(description, [StrEvaluator(PROCESS_ARGV, EXACT, "-rf")])
 			name:         "single argument",
 			inputJSON:    `{"args": [{"args": ["-rf"]}], "description": "deny -rf flag"}`,
-			expectedRoot: strEval(wls.StringEvaluatorsPROCESS_ARGV, "-rf"),
+			expectedRoot: andNode(strEval(wls.StringEvaluatorsPROCESS_ARGV, "-rf")),
 		},
 	}
 


### PR DESCRIPTION
Add `plcs_eval_ctx_get_matched_description()` to report the description of the specific node at depth 0 that triggered the policies action. For example, if [this "deny" rule](https://github.com/DataDog/dd-trace-js/blob/1382cfd4de26e61ea2dd2a17e885d53e73a37bd1/requirements.json#L45-L52) in the dd-trace-js  `requirements.json` gets matched and triggers the `PLCS_ACTION_INJECT_DENY` action:
`    {
      "id": "npm",
      "description": "Ignore the npm CLI",
      "os": null,
      "cmds": [],
      "args": [{ "args":  ["*/npm-cli.js"], "position": 1}],
      "envars": null
    },`, then `plcs_eval_ctx_get_matched_description()` would return "Ignore npm CLI".

https://datadoghq.atlassian.net/browse/INPLAT-1155