### PR TITLE
feat(schema): add container image tag, digest, name, and label evaluators

### DIFF
--- a/c/include/dd/policies/evaluator_types.h
+++ b/c/include/dd/policies/evaluator_types.h
@@ -99,7 +99,11 @@ typedef enum plcs_numeric_comparator {
   X(PROCESS_ARGV_N_4, 44)                                                                                              \
   X(PROCESS_ARGV_N_5, 45)                                                                                              \
   X(PROCESS_ARGV_N_6, 46)                                                                                              \
-  X(PROCESS_ENVAR, 47)
+  X(PROCESS_ENVAR, 47)                                                                                                 \
+  X(CONTAINER_IMAGE_TAG, 48)                                                                                           \
+  X(CONTAINER_IMAGE_DIGEST, 49)                                                                                        \
+  X(CONTAINER_NAME, 50)                                                                                                \
+  X(CONTAINER_LABEL, 51)
 
 #define ENUM_STR_CMP_EVAL(ID, IX) PLCS_STR_EVAL_##ID = IX,
 typedef enum plcs_string_evaluators {

--- a/c/src/schema/evaluator_ids_reader.h
+++ b/c/src/schema/evaluator_ids_reader.h
@@ -74,7 +74,11 @@ __flatbuffers_define_integer_type(dd_wls_StringEvaluators, dd_wls_StringEvaluato
 #define dd_wls_StringEvaluators_PROCESS_ARGV_N_5 ((dd_wls_StringEvaluators_enum_t)INT8_C(45))
 #define dd_wls_StringEvaluators_PROCESS_ARGV_N_6 ((dd_wls_StringEvaluators_enum_t)INT8_C(46))
 #define dd_wls_StringEvaluators_PROCESS_ENVAR ((dd_wls_StringEvaluators_enum_t)INT8_C(47))
-#define dd_wls_StringEvaluators_STR_EVAL_COUNT ((dd_wls_StringEvaluators_enum_t)INT8_C(48))
+#define dd_wls_StringEvaluators_CONTAINER_IMAGE_TAG ((dd_wls_StringEvaluators_enum_t)INT8_C(48))
+#define dd_wls_StringEvaluators_CONTAINER_IMAGE_DIGEST ((dd_wls_StringEvaluators_enum_t)INT8_C(49))
+#define dd_wls_StringEvaluators_CONTAINER_NAME ((dd_wls_StringEvaluators_enum_t)INT8_C(50))
+#define dd_wls_StringEvaluators_CONTAINER_LABEL ((dd_wls_StringEvaluators_enum_t)INT8_C(51))
+#define dd_wls_StringEvaluators_STR_EVAL_COUNT ((dd_wls_StringEvaluators_enum_t)INT8_C(52))
 
 static inline const char *dd_wls_StringEvaluators_name(dd_wls_StringEvaluators_enum_t value)
 {
@@ -127,6 +131,10 @@ static inline const char *dd_wls_StringEvaluators_name(dd_wls_StringEvaluators_e
     case dd_wls_StringEvaluators_PROCESS_ARGV_N_5: return "PROCESS_ARGV_N_5";
     case dd_wls_StringEvaluators_PROCESS_ARGV_N_6: return "PROCESS_ARGV_N_6";
     case dd_wls_StringEvaluators_PROCESS_ENVAR: return "PROCESS_ENVAR";
+    case dd_wls_StringEvaluators_CONTAINER_IMAGE_TAG: return "CONTAINER_IMAGE_TAG";
+    case dd_wls_StringEvaluators_CONTAINER_IMAGE_DIGEST: return "CONTAINER_IMAGE_DIGEST";
+    case dd_wls_StringEvaluators_CONTAINER_NAME: return "CONTAINER_NAME";
+    case dd_wls_StringEvaluators_CONTAINER_LABEL: return "CONTAINER_LABEL";
     case dd_wls_StringEvaluators_STR_EVAL_COUNT: return "STR_EVAL_COUNT";
     default: return "";
     }
@@ -183,6 +191,10 @@ static inline int dd_wls_StringEvaluators_is_known_value(dd_wls_StringEvaluators
     case dd_wls_StringEvaluators_PROCESS_ARGV_N_5: return 1;
     case dd_wls_StringEvaluators_PROCESS_ARGV_N_6: return 1;
     case dd_wls_StringEvaluators_PROCESS_ENVAR: return 1;
+    case dd_wls_StringEvaluators_CONTAINER_IMAGE_TAG: return 1;
+    case dd_wls_StringEvaluators_CONTAINER_IMAGE_DIGEST: return 1;
+    case dd_wls_StringEvaluators_CONTAINER_NAME: return 1;
+    case dd_wls_StringEvaluators_CONTAINER_LABEL: return 1;
     case dd_wls_StringEvaluators_STR_EVAL_COUNT: return 1;
     default: return 0;
     }

--- a/fbs-schema/evaluator_ids.fbs
+++ b/fbs-schema/evaluator_ids.fbs
@@ -92,6 +92,15 @@ enum StringEvaluators : byte {
 
     PROCESS_ENVAR,  // Check "KEY=VALUE" pattern, with CMP_WILDCARD can check wildcards too
 
+    /// The tag portion of the container image reference (e.g. "latest", "v2.1")
+    CONTAINER_IMAGE_TAG,
+    /// The OCI image digest, including the algorithm prefix (e.g. "sha256:abc123...")
+    CONTAINER_IMAGE_DIGEST,
+    /// The human-readable container name assigned by the container runtime
+    CONTAINER_NAME,
+    /// A container label as "KEY=VALUE", with CMP_WILDCARD can check wildcards too
+    CONTAINER_LABEL,
+    
     /// Represents the count of String evaluators.
     /// This is used to ensure that the enum is always in sync with the number of evaluators.
     /// IMPORTANT! When adding a new evaluator make sure you add it BEFORE this entry.

--- a/go/schema/dd/wls/StringEvaluators.go
+++ b/go/schema/dd/wls/StringEvaluators.go
@@ -79,10 +79,18 @@ const (
 	StringEvaluatorsPROCESS_ARGV_N_5            StringEvaluators = 45
 	StringEvaluatorsPROCESS_ARGV_N_6            StringEvaluators = 46
 	StringEvaluatorsPROCESS_ENVAR               StringEvaluators = 47
+	/// The tag portion of the container image reference (e.g. "latest", "v2.1")
+	StringEvaluatorsCONTAINER_IMAGE_TAG         StringEvaluators = 48
+	/// The OCI image digest, including the algorithm prefix (e.g. "sha256:abc123...")
+	StringEvaluatorsCONTAINER_IMAGE_DIGEST      StringEvaluators = 49
+	/// The human-readable container name assigned by the container runtime
+	StringEvaluatorsCONTAINER_NAME              StringEvaluators = 50
+	/// A container label as "KEY=VALUE", with CMP_WILDCARD can check wildcards too
+	StringEvaluatorsCONTAINER_LABEL             StringEvaluators = 51
 	/// Represents the count of String evaluators.
 	/// This is used to ensure that the enum is always in sync with the number of evaluators.
 	/// IMPORTANT! When adding a new evaluator make sure you add it BEFORE this entry.
-	StringEvaluatorsSTR_EVAL_COUNT              StringEvaluators = 48
+	StringEvaluatorsSTR_EVAL_COUNT              StringEvaluators = 52
 )
 
 var EnumNamesStringEvaluators = map[StringEvaluators]string{
@@ -134,6 +142,10 @@ var EnumNamesStringEvaluators = map[StringEvaluators]string{
 	StringEvaluatorsPROCESS_ARGV_N_5:            "PROCESS_ARGV_N_5",
 	StringEvaluatorsPROCESS_ARGV_N_6:            "PROCESS_ARGV_N_6",
 	StringEvaluatorsPROCESS_ENVAR:               "PROCESS_ENVAR",
+	StringEvaluatorsCONTAINER_IMAGE_TAG:         "CONTAINER_IMAGE_TAG",
+	StringEvaluatorsCONTAINER_IMAGE_DIGEST:      "CONTAINER_IMAGE_DIGEST",
+	StringEvaluatorsCONTAINER_NAME:              "CONTAINER_NAME",
+	StringEvaluatorsCONTAINER_LABEL:             "CONTAINER_LABEL",
 	StringEvaluatorsSTR_EVAL_COUNT:              "STR_EVAL_COUNT",
 }
 
@@ -186,6 +198,10 @@ var EnumValuesStringEvaluators = map[string]StringEvaluators{
 	"PROCESS_ARGV_N_5":            StringEvaluatorsPROCESS_ARGV_N_5,
 	"PROCESS_ARGV_N_6":            StringEvaluatorsPROCESS_ARGV_N_6,
 	"PROCESS_ENVAR":               StringEvaluatorsPROCESS_ENVAR,
+	"CONTAINER_IMAGE_TAG":         StringEvaluatorsCONTAINER_IMAGE_TAG,
+	"CONTAINER_IMAGE_DIGEST":      StringEvaluatorsCONTAINER_IMAGE_DIGEST,
+	"CONTAINER_NAME":              StringEvaluatorsCONTAINER_NAME,
+	"CONTAINER_LABEL":             StringEvaluatorsCONTAINER_LABEL,
 	"STR_EVAL_COUNT":              StringEvaluatorsSTR_EVAL_COUNT,
 }
 


### PR DESCRIPTION
### Overview
Adds four container string evaluators (CONTAINER_IMAGE_TAG, CONTAINER_IMAGE_DIGEST, CONTAINER_NAME, CONTAINER_LABEL) to the StringEvaluators enum

[INPLAT-1162](https://datadoghq.atlassian.net/browse/INPLAT-1162)

### Changes
Appends the four entries (IDs 48–51) to fbs-schema/evaluator_ids.fbs and the PLCS_LIST_STRING_EVALUATORS X-macro in c/include/dd/policies/evaluator_types.h, regenerates c/src/schema/evaluator_ids_reader.h and go/schema/dd/wls/StringEvaluators.go via make

### Testing
make all, make c-test, and make go-test all pass; new constants verified present in both generated files (PLCS_STR_EVAL_CONTAINER_* = 48–51) and existing IDs unchanged

[INPLAT-1162]: https://datadoghq.atlassian.net/browse/INPLAT-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ