### PR TITLE
[codex] Add workload selection compatibility examples

### DIFF
--- a/dd-compile-policy/examples/workload_selection_compat/README.md
+++ b/dd-compile-policy/examples/workload_selection_compat/README.md
@@ -1,0 +1,47 @@
+# Workload Selection Compatibility Examples
+
+These examples document how old `dd-compile-policy` binaries handle JSON shapes
+that may be useful for future Kubernetes workload selection and tracer injection
+configuration.
+
+The Agent passes APM workload selection Remote Config payloads to
+`dd-compile-policy --input-string ...`. The compiler is strict about object
+fields, but older compiler builds fall back to enum value `0` for unknown enum
+names.
+
+## Future Enums
+
+`future_action_and_k8s_selectors.json` shows a possible future policy shape:
+
+- `INJECT_TRACERS` action with `JAVA:1.42.0` in `values`.
+- Kubernetes tag/label evaluators using `In`, `NotIn`, and `Exists`-style
+  matching.
+
+Current old compilers accept this JSON, but encode the unknown enum names as
+their `*_UNKNOWN` values:
+
+- `INJECT_TRACERS` becomes `ACTION_UNKNOWN`.
+- `K8S_POD_LABEL` and `K8S_NAMESPACE_LABEL` become `STRING_EVAL_UNKNOWN`.
+- `CMP_K8S_IN`, `CMP_K8S_NOT_IN`, and `CMP_K8S_EXISTS` become
+  `CMP_STR_UNKNOWN`.
+
+The string payloads, such as `JAVA:1.42.0` and `app=checkout`, are preserved in
+the buffer. On old runtimes, the resulting action is a no-op and the future
+selectors evaluate as abstain.
+
+## Opaque Metadata
+
+`opaque_target_metadata.json` shows target metadata encoded as strings in
+existing schema fields. Old compilers accept this because the data is just a
+string in `description` and `actions.values`.
+
+This is only transport-compatible. A runtime or action handler must explicitly
+parse the string payload for it to affect behavior.
+
+## Rejected Fields
+
+Do not place the `Target`-style fields from the Cluster Agent
+autoinstrumentation config directly on a `Policy`. Old compilers reject that
+shape with `unknown field`, because fields such as `name`, `podSelector`,
+`namespaceSelector`, `ddTraceVersions`, and `ddTraceConfigs` are not fields in
+the FlatBuffers `Policy` table.

--- a/dd-compile-policy/examples/workload_selection_compat/future_action_and_k8s_selectors.json
+++ b/dd-compile-policy/examples/workload_selection_compat/future_action_and_k8s_selectors.json
@@ -1,0 +1,59 @@
+{
+  "policies": [
+    {
+      "description": "future k8s selector evaluators",
+      "rules": {
+        "node_type": "CompositeNode",
+        "node": {
+          "description": "target pod and namespace selectors",
+          "op": "BOOL_AND",
+          "children": [
+            {
+              "node_type": "EvaluatorNode",
+              "node": {
+                "description": "pod label app In checkout",
+                "eval_type": "StrEvaluator",
+                "eval": {
+                  "id": "K8S_POD_LABEL",
+                  "cmp": "CMP_K8S_IN",
+                  "value": "app=checkout"
+                }
+              }
+            },
+            {
+              "node_type": "EvaluatorNode",
+              "node": {
+                "description": "namespace label team NotIn legacy",
+                "eval_type": "StrEvaluator",
+                "eval": {
+                  "id": "K8S_NAMESPACE_LABEL",
+                  "cmp": "CMP_K8S_NOT_IN",
+                  "value": "team=legacy"
+                }
+              }
+            },
+            {
+              "node_type": "EvaluatorNode",
+              "node": {
+                "description": "pod label env Exists",
+                "eval_type": "StrEvaluator",
+                "eval": {
+                  "id": "K8S_POD_LABEL",
+                  "cmp": "CMP_K8S_EXISTS",
+                  "value": "env"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "actions": [
+        {
+          "action": "INJECT_TRACERS",
+          "description": "inject tracer versions",
+          "values": ["JAVA:1.42.0"]
+        }
+      ]
+    }
+  ]
+}

--- a/dd-compile-policy/examples/workload_selection_compat/opaque_target_metadata.json
+++ b/dd-compile-policy/examples/workload_selection_compat/opaque_target_metadata.json
@@ -1,0 +1,29 @@
+{
+  "policies": [
+    {
+      "description": "{\"target\":{\"name\":\"checkout\",\"podSelector\":{\"matchLabels\":{\"app\":\"checkout\"}},\"namespaceSelector\":{\"matchNames\":[\"prod\"]},\"ddTraceVersions\":{\"java\":\"1.42.0\"},\"ddTraceConfigs\":[{\"name\":\"DD_SERVICE\",\"value\":\"checkout\"}]}}",
+      "rules": {
+        "node_type": "EvaluatorNode",
+        "node": {
+          "description": "runtime is java",
+          "eval_type": "StrEvaluator",
+          "eval": {
+            "id": "RUNTIME_LANGUAGE",
+            "cmp": "CMP_EXACT",
+            "value": "java"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action": "INJECT_TRACERS",
+          "description": "target metadata carried as action values",
+          "values": [
+            "JAVA:1.42.0",
+            "{\"name\":\"checkout\",\"podSelector\":{\"matchLabels\":{\"app\":\"checkout\"}},\"namespaceSelector\":{\"matchNames\":[\"prod\"]},\"ddTraceVersions\":{\"java\":\"1.42.0\"},\"ddTraceConfigs\":[{\"name\":\"DD_SERVICE\",\"value\":\"checkout\"}]}"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Add `dd-compile-policy` examples documenting workload selection compatibility for future tracer injection and Kubernetes selector payloads.

The examples cover:
- future enum names for `INJECT_TRACERS` and K8s selector evaluators
- opaque target metadata carried through existing string fields
- notes on target-shaped policy fields that old compilers reject

## Why

The Agent passes APM workload selection RC payloads through `dd-compile-policy`. These examples make the compatibility behavior explicit: unknown object fields are rejected, while unknown enum names compile to their `*_UNKNOWN` values and become no-ops on old runtimes.

## Validation

- `git diff --check`
- Compiled `future_action_and_k8s_selectors.json` with `dd-compile-policy` v0.1.2 in Docker
- Compiled `opaque_target_metadata.json` with `dd-compile-policy` v0.1.2 in Docker
