### PR TITLE
Add rule_id field to Policy to identify matched rule

### DIFF
--- a/c/src/schema/policy_builder.h
+++ b/c/src/schema/policy_builder.h
@@ -49,7 +49,7 @@ __flatbuffers_define_fixed_array_primitives(flatbuffers_, dd_wls_UUID, dd_wls_UU
 static const flatbuffers_voffset_t __dd_wls_Policy_required[] = { 0 };
 typedef flatbuffers_ref_t dd_wls_Policy_ref_t;
 static dd_wls_Policy_ref_t dd_wls_Policy_clone(flatbuffers_builder_t *B, dd_wls_Policy_table_t t);
-__flatbuffers_build_table(flatbuffers_, dd_wls_Policy, 5)
+__flatbuffers_build_table(flatbuffers_, dd_wls_Policy, 6)
 
 static const flatbuffers_voffset_t __dd_wls_Policies_required[] = { 0 };
 typedef flatbuffers_ref_t dd_wls_Policies_ref_t;
@@ -57,9 +57,9 @@ static dd_wls_Policies_ref_t dd_wls_Policies_clone(flatbuffers_builder_t *B, dd_
 __flatbuffers_build_table(flatbuffers_, dd_wls_Policies, 1)
 
 #define __dd_wls_Policy_formal_args ,\
-  flatbuffers_string_ref_t v0, dd_wls_NodeTypeWrapper_ref_t v1, dd_wls_Action_vec_ref_t v2, dd_wls_UUID_t *v3, int64_t v4
+  flatbuffers_string_ref_t v0, dd_wls_NodeTypeWrapper_ref_t v1, dd_wls_Action_vec_ref_t v2, dd_wls_UUID_t *v3, int64_t v4, flatbuffers_string_ref_t v5
 #define __dd_wls_Policy_call_args ,\
-  v0, v1, v2, v3, v4
+  v0, v1, v2, v3, v4, v5
 static inline dd_wls_Policy_ref_t dd_wls_Policy_create(flatbuffers_builder_t *B __dd_wls_Policy_formal_args);
 __flatbuffers_build_table_prolog(flatbuffers_, dd_wls_Policy, dd_wls_Policy_file_identifier, dd_wls_Policy_type_identifier)
 
@@ -73,6 +73,7 @@ __flatbuffers_build_table_field(1, flatbuffers_, dd_wls_Policy_rules, dd_wls_Nod
 __flatbuffers_build_table_vector_field(2, flatbuffers_, dd_wls_Policy_actions, dd_wls_Action, dd_wls_Policy)
 __flatbuffers_build_struct_field(3, flatbuffers_, dd_wls_Policy_id, dd_wls_UUID, 16, 8, dd_wls_Policy)
 __flatbuffers_build_scalar_field(4, flatbuffers_, dd_wls_Policy_version, flatbuffers_int64, int64_t, 8, 8, INT64_C(0), dd_wls_Policy)
+__flatbuffers_build_string_field(5, flatbuffers_, dd_wls_Policy_rule_id, dd_wls_Policy)
 
 static inline dd_wls_Policy_ref_t dd_wls_Policy_create(flatbuffers_builder_t *B __dd_wls_Policy_formal_args)
 {
@@ -81,7 +82,8 @@ static inline dd_wls_Policy_ref_t dd_wls_Policy_create(flatbuffers_builder_t *B 
         || dd_wls_Policy_version_add(B, v4)
         || dd_wls_Policy_description_add(B, v0)
         || dd_wls_Policy_rules_add(B, v1)
-        || dd_wls_Policy_actions_add(B, v2)) {
+        || dd_wls_Policy_actions_add(B, v2)
+        || dd_wls_Policy_rule_id_add(B, v5)) {
         return 0;
     }
     return dd_wls_Policy_end(B);
@@ -95,7 +97,8 @@ static dd_wls_Policy_ref_t dd_wls_Policy_clone(flatbuffers_builder_t *B, dd_wls_
         || dd_wls_Policy_version_pick(B, t)
         || dd_wls_Policy_description_pick(B, t)
         || dd_wls_Policy_rules_pick(B, t)
-        || dd_wls_Policy_actions_pick(B, t)) {
+        || dd_wls_Policy_actions_pick(B, t)
+        || dd_wls_Policy_rule_id_pick(B, t)) {
         return 0;
     }
     __flatbuffers_memoize_end(B, t, dd_wls_Policy_end(B));

--- a/c/src/schema/policy_reader.h
+++ b/c/src/schema/policy_reader.h
@@ -119,6 +119,12 @@ __flatbuffers_define_vector_field(2, dd_wls_Policy, actions, dd_wls_Action_vec_t
 __flatbuffers_define_struct_field(3, dd_wls_Policy, id, dd_wls_UUID_struct_t, 0)
 /**  used to track the version number of this policy */
 __flatbuffers_define_scalar_field(4, dd_wls_Policy, version, flatbuffers_int64, int64_t, INT64_C(0))
+/**  Stable identifier of the rule this policy represents, used to attribute an
+ *  evaluation outcome back to its source rule (for example, linking a skipped
+ *  or instrumented process back to the rule on the Instrumentation Rules page).
+ *  For Remote Config rules this is the rule's UUID; for hardcoded/built-in
+ *  policies it is the sentinel "hardcoded". */
+__flatbuffers_define_string_field(5, dd_wls_Policy, rule_id, 0)
 
 /**  Represents a collection of policies.
  *  This allows for concatenation of policies from different sources.

--- a/c/src/schema/policy_verifier.h
+++ b/c/src/schema/policy_verifier.h
@@ -66,6 +66,7 @@ static int dd_wls_Policy_verify_table(flatcc_table_verifier_descriptor_t *td)
     if ((ret = flatcc_verify_table_vector_field(td, 2, 0, &dd_wls_Action_verify_table) /* actions */)) return ret;
     if ((ret = flatcc_verify_field(td, 3, 16, 8) /* id */)) return ret;
     if ((ret = flatcc_verify_field(td, 4, 8, 8) /* version */)) return ret;
+    if ((ret = flatcc_verify_string_field(td, 5, 0) /* rule_id */)) return ret;
     return flatcc_verify_ok;
 }
 

--- a/fbs-schema/policy.fbs
+++ b/fbs-schema/policy.fbs
@@ -28,6 +28,12 @@ table Policy {
   id:UUID;
   /// used to track the version number of this policy
   version: long=0;
+  /// Stable identifier of the rule this policy represents, used to attribute an
+  /// evaluation outcome back to its source rule (for example, linking a skipped
+  /// or instrumented process back to the rule on the Instrumentation Rules page).
+  /// For Remote Config rules this is the rule's UUID; for hardcoded/built-in
+  /// policies it is the sentinel "hardcoded".
+  rule_id: string;
 }
 
 /// Represents a collection of policies.

--- a/go/schema/dd/wls/Policy.go
+++ b/go/schema/dd/wls/Policy.go
@@ -121,8 +121,21 @@ func (rcv *Policy) MutateVersion(n int64) bool {
 	return rcv._tab.MutateInt64Slot(12, n)
 }
 
+/// Stable identifier of the rule this policy represents, used to attribute an
+/// evaluation outcome back to its source rule (for example, linking a skipped
+/// or instrumented process back to the rule on the Instrumentation Rules page).
+/// For Remote Config rules this is the rule's UUID; for hardcoded/built-in
+/// policies it is the sentinel "hardcoded".
+func (rcv *Policy) RuleId() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func PolicyStart(builder *flatbuffers.Builder) {
-	builder.StartObject(5)
+	builder.StartObject(6)
 }
 func PolicyAddDescription(builder *flatbuffers.Builder, description flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(description), 0)
@@ -141,6 +154,9 @@ func PolicyAddId(builder *flatbuffers.Builder, id flatbuffers.UOffsetT) {
 }
 func PolicyAddVersion(builder *flatbuffers.Builder, version int64) {
 	builder.PrependInt64Slot(4, version, 0)
+}
+func PolicyAddRuleId(builder *flatbuffers.Builder, ruleId flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(5, flatbuffers.UOffsetT(ruleId), 0)
 }
 func PolicyEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()


### PR DESCRIPTION
Adds a `rule_id` field to the `Policy` table in the FlatBuffers schema so an evaluation outcome can be traced back to the rule that produced it. For Remote Config rules this carries the rule's UUID; for hardcoded/built-in policies it is the label "hardcoded".

This is the schema groundwork for surfacing the deciding rule in injection telemetry and linking a skipped or instrumented process back to its rule on the Instrumentation Rules page.