### PR TITLE
Migrate DD_API_KEY_CI_VIS_APP from GitHub secret to dd-sts

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,11 +35,10 @@ jobs:
             runner: ubuntu-22.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
-    environment:
-      name: dev-env
     permissions:
       contents: read
       packages: read
+      id-token: write
     env:
       DD_ENV: ci
       DD_SERVICE: dd-policy-engine
@@ -47,6 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: dd-policy-engine-ci-vis
       - name: Build
         run: make docker-run "make -C c test-build"
         env:
@@ -58,7 +62,7 @@ jobs:
       - name: Report test coverage
         uses: datadog/junit-upload-github-action@8bd322523583035e871786a19832d75127064227 # v3.5.0
         with:
-          api_key: ${{ secrets.DD_API_KEY_CI_VIS_APP }}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           files: c/build/test-report.xml
           service: libpolicies
           tags: test.source.file:test/*.cpp
@@ -159,19 +163,22 @@ jobs:
     defaults:
       run:
         shell: powershell
-    environment:
-      name: dev-env
     permissions:
       contents: read
       packages: read
+      id-token: write
     env:
       DD_ENV: ci
       DD_SERVICE: dd-policy-engine
-      DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VIS_APP }}
       DD_CIVISIBILITY_AGENTLESS_ENABLED: true
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: dd-policy-engine-ci-vis
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
@@ -187,13 +194,19 @@ jobs:
         run: |
           cmake -B build --preset msvc-ci .
           cmake --build build -j
+        env:
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       - name: Run tests
         run: ctest --test-dir build --output-junit test-report.xml
         timeout-minutes: 2
+        env:
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       - name: Download datadog-ci
         run: Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64" -OutFile "datadog-ci.exe"
       - name: Report test coverage
         run: ./datadog-ci.exe junit upload build/test-report.xml
+        env:
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
 
   build-go-windows:
     runs-on: windows-2022
@@ -216,13 +229,17 @@ jobs:
     needs: build-libpolicies-linux
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 10
-    environment:
-      name: dev-env
     permissions:
       contents: read
       packages: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: dd-policy-engine-ci-vis
       - run: make docker-run "make -C c coverage"
       - name: Upload coverage reports to Datadog
         run: |
@@ -231,4 +248,4 @@ jobs:
           mv c/coverage/coverage.lcov c/coverage/lcov.info
           /tmp/datadog-ci coverage upload c/coverage/lcov.info
         env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VIS_APP }}
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}


### PR DESCRIPTION
## Summary

- Replace the long-lived `DD_API_KEY_CI_VIS_APP` GitHub secret with short-lived credentials from `dd-sts` via `DataDog/dd-sts-action@v1.0.0`
- Updated 3 jobs in `dev.yml`: `build-libpolicies-linux`, `build-libpolicies-windows`, and `coverage`
- Added `id-token: write` permission to each job for OIDC token federation

## Prerequisites

A dd-sts policy named `dd-policy-engine-ci-vis` must be created and deployed in dd-source **before** merging this PR. The policy should be added at:
```
dd-source/domains/seceng/sit/apps/apis/dd-sts/config/policies/us1.ddbuild.io/dd-policy-engine-ci-vis.yaml
```

Example policy:
```yaml
issuer: https://token.actions.githubusercontent.com

subject_pattern: "repo:DataDog/dd-policy-engine:.*"

claim_pattern:
  repository: DataDog/dd-policy-engine

org_id: 2

team: "<team-slug>"
```

## Context

Requested by SDLC Security (Nicole) to migrate long-lived credentials in GitHub Actions to dd-sts. See [dd-sts user guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5769659435/User+guide+dd-sts).

## Test plan

- [ ] Create dd-sts policy in dd-source and get it reviewed in #sdlc-security-reviews
- [ ] Wait for dd-sts policy deployment
- [ ] Run this PR's CI and verify all 3 jobs (linux build, windows build, coverage) pass with dd-sts credentials
- [ ] Remove `DD_API_KEY_CI_VIS_APP` secret from repo settings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)