### PR TITLE
Stamp hardcoded policies with id="hardcoded"

### DIFF
--- a/go/cmd/dd-requirements-converter/converter/requirements.go
+++ b/go/cmd/dd-requirements-converter/converter/requirements.go
@@ -59,6 +59,6 @@ func (r JSONRequirements) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffer
 	compositeNode := schema.NodeTypeWrapperCreate(builder, composite, wls.NodeTypeCompositeNode)
 
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_DENY, "requirements", nil)
-	policy := schema.PolicyCreate(builder, "All requirements", compositeNode, []flatbuffers.UOffsetT{action})
+	policy := schema.PolicyCreate(builder, "All requirements", compositeNode, []flatbuffers.UOffsetT{action}, "")
 	return schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy}), nil
 }

--- a/go/cmd/dd-requirements-converter/converter/requirements.go
+++ b/go/cmd/dd-requirements-converter/converter/requirements.go
@@ -59,6 +59,6 @@ func (r JSONRequirements) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffer
 	compositeNode := schema.NodeTypeWrapperCreate(builder, composite, wls.NodeTypeCompositeNode)
 
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_DENY, "requirements", nil)
-	policy := schema.PolicyCreate(builder, "All requirements", compositeNode, []flatbuffers.UOffsetT{action}, "")
+	policy := schema.PolicyCreate(builder, "All requirements", compositeNode, []flatbuffers.UOffsetT{action}, "hardcoded")
 	return schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy}), nil
 }

--- a/go/cmd/dd-rules-converter/main.go
+++ b/go/cmd/dd-rules-converter/main.go
@@ -254,6 +254,6 @@ func addRule(builder *PolicyBuilder, id string, description string, ast parser.A
 	nodeRoot := createConditionalNode(builder.builder, wls.BoolOperationBOOL_AND, id, nodes)
 	action := schema.ActionCreate(builder.builder, actionKind, id, []string{})
 
-	builder.offsets = append(builder.offsets, schema.PolicyCreate(builder.builder, description, nodeRoot, []flatbuffers.UOffsetT{action}))
+	builder.offsets = append(builder.offsets, schema.PolicyCreate(builder.builder, description, nodeRoot, []flatbuffers.UOffsetT{action}, ""))
 	return nil
 }

--- a/go/examples/example_generate_c_header_buffer/main.go
+++ b/go/examples/example_generate_c_header_buffer/main.go
@@ -38,7 +38,7 @@ func createDenyByRuntimePolicy(builder *flatbuffers.Builder, runtime string) fla
 	// Start by creating the leaf evaluator (StrEvaluator for runtime language check)
 	node := createStrEvaluatorNode(builder, wls.StringEvaluatorsRUNTIME_LANGUAGE, runtime, wls.CmpTypeSTRCMP_EXACT, "Validate runtime is "+runtime)
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_DENY, "Deny "+runtime+" runtime!", []string{"value_1", "value_2", "value_3"})
-	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", node, []flatbuffers.UOffsetT{action})
+	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", node, []flatbuffers.UOffsetT{action}, "")
 }
 
 func generateCHeader(varName string, data []byte) string {

--- a/go/examples/example_json_to_hardcoded_injector_policies/converter/policy.go
+++ b/go/examples/example_json_to_hardcoded_injector_policies/converter/policy.go
@@ -75,5 +75,5 @@ func (p JSONPolicy) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffers.UOff
 
 	action := schema.ActionCreate(builder, GetActionId(p.Skip), p.Description, []string{p.Runtime})
 
-	return schema.PolicyCreate(builder, p.Description, root, []flatbuffers.UOffsetT{action}), nil
+	return schema.PolicyCreate(builder, p.Description, root, []flatbuffers.UOffsetT{action}, "hardcoded"), nil
 }

--- a/go/examples/example_writer/main.go
+++ b/go/examples/example_writer/main.go
@@ -45,7 +45,7 @@ func createDenyByRuntimePolicy(builder *flatbuffers.Builder, runtime string) fla
 	// Start by creating the leaf evaluator (StrEvaluator for runtime language check)
 	node := createStrEvaluatorNode(builder, wls.StringEvaluatorsRUNTIME_LANGUAGE, runtime, wls.CmpTypeSTRCMP_EXACT, "Validate runtime is "+runtime)
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_DENY, "Deny "+runtime+" runtime!", []string{"value_1", "value_2", "value_3"})
-	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", node, []flatbuffers.UOffsetT{action})
+	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", node, []flatbuffers.UOffsetT{action}, "")
 }
 
 func createRoot(builder *flatbuffers.Builder, oper wls.BoolOperation, description string, nodes []flatbuffers.UOffsetT) flatbuffers.UOffsetT {
@@ -63,7 +63,7 @@ func createDenyByMultipleEvaluatorsPolicy(builder *flatbuffers.Builder, runtime 
 	nodeRoot := createRoot(builder, wls.BoolOperationBOOL_AND, "evaluate if runtime and exe prefix equal to something :)", []flatbuffers.UOffsetT{nodeRuntime, nodeExePrefix})
 
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_DENY, "Deny "+runtime+" runtime!", []string{"value_1", "value_2", "value_3"})
-	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", nodeRoot, []flatbuffers.UOffsetT{action})
+	return schema.PolicyCreate(builder, "DenyByRuntimePolicy("+runtime+")", nodeRoot, []flatbuffers.UOffsetT{action}, "")
 
 }
 
@@ -109,7 +109,7 @@ func createFlatPolicyNoEvaluators() string {
 	fileName := "FlatPolicyNoEvaluators.bin"
 	builder := flatbuffers.NewBuilder(1024)
 	action := schema.ActionCreate(builder, wls.ActionIdINJECT_ALLOW, "These actions will execute without executing any evaluators", []string{"value_1", "value_2", "value_3", "value_4", "value_5"})
-	policy := schema.PolicyCreate(builder, "AllowAllPolicy", 0, []flatbuffers.UOffsetT{action})
+	policy := schema.PolicyCreate(builder, "AllowAllPolicy", 0, []flatbuffers.UOffsetT{action}, "")
 	policies := schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy})
 
 	builder.Finish(policies)
@@ -121,7 +121,7 @@ func createFlatPolicyNoEvaluators() string {
 func createEmptyPolicies() string {
 	fileName := "EmptyPolicies.bin"
 	builder := flatbuffers.NewBuilder(1024)
-	policy := schema.PolicyCreate(builder, "EmptyPolicy", 0, []flatbuffers.UOffsetT{})
+	policy := schema.PolicyCreate(builder, "EmptyPolicy", 0, []flatbuffers.UOffsetT{}, "")
 	policies := schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy})
 
 	builder.Finish(policies)
@@ -134,7 +134,7 @@ func createFlatPolicyNoActions() string {
 	fileName := "FlatPolicyNoActions.bin"
 	builder := flatbuffers.NewBuilder(1024)
 	node := createStrEvaluatorNode(builder, wls.StringEvaluatorsRUNTIME_LANGUAGE, "some runtime", wls.CmpTypeSTRCMP_EXACT, "Validate runtime is some runtime")
-	policy := schema.PolicyCreate(builder, "PolicyWithoutActions", node, []flatbuffers.UOffsetT{})
+	policy := schema.PolicyCreate(builder, "PolicyWithoutActions", node, []flatbuffers.UOffsetT{}, "")
 	policies := schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy})
 
 	builder.Finish(policies)
@@ -146,7 +146,7 @@ func createFlatPolicyNoActions() string {
 func createZeropPolicies() string {
 	fileName := "ZeropPolicies.bin"
 	builder := flatbuffers.NewBuilder(1024)
-	policy := schema.PolicyCreate(builder, "EmptyPolicy", 0, []flatbuffers.UOffsetT{})
+	policy := schema.PolicyCreate(builder, "EmptyPolicy", 0, []flatbuffers.UOffsetT{}, "")
 	policies := schema.PoliciesCreate(builder, []flatbuffers.UOffsetT{policy})
 
 	builder.Finish(policies)

--- a/go/schema/Creators.go
+++ b/go/schema/Creators.go
@@ -83,14 +83,21 @@ func NodeTypeWrapperCreate(builder *flatbuffers.Builder, nodeOffset flatbuffers.
 	return wls.NodeTypeWrapperEnd(builder)
 }
 
-func PolicyCreate(builder *flatbuffers.Builder, description string, rulesRoot flatbuffers.UOffsetT, actions []flatbuffers.UOffsetT) flatbuffers.UOffsetT {
+func PolicyCreate(builder *flatbuffers.Builder, description string, rulesRoot flatbuffers.UOffsetT, actions []flatbuffers.UOffsetT, id string) flatbuffers.UOffsetT {
 	fbDescription := builder.CreateString(description)
 	actionsVector := builder.CreateVectorOfTables(actions)
+	var fbID flatbuffers.UOffsetT
+	if id != "" {
+		fbID = builder.CreateString(id)
+	}
 
 	wls.PolicyStart(builder)
 	wls.PolicyAddDescription(builder, fbDescription)
 	wls.PolicyAddRules(builder, rulesRoot)
 	wls.PolicyAddActions(builder, actionsVector)
+	if id != "" {
+		wls.PolicyAddId(builder, fbID)
+	}
 
 	return wls.PolicyEnd(builder)
 }


### PR DESCRIPTION
Stamps `id="hardcoded"` onto the hardcoded flatbuffers policies (workload_selection_hardcoded.bin, requirements.bin), so that when `auto_inject` consumes these policy files, the `id` field is populated.