### PR TITLE
Expose current policy id via eval_ctx getter

### DIFF
--- a/c/include/dd/policies/eval_ctx.h
+++ b/c/include/dd/policies/eval_ctx.h
@@ -173,6 +173,12 @@ plcs_errors plcs_eval_ctx_get_last_error(void);
 plcs_errors plcs_eval_ctx_peek_last_error(void);
 
 /**
+ * @brief Gets the id of the policy currently being evaluated.
+ * @return the current policy's id, or PLCS_STR_NOT_SET (NULL) if none is being evaluated.
+ */
+const char *plcs_eval_ctx_get_current_policy_id(void);
+
+/**
  * @brief Initializes the context model.
  * This function sets all evaluator function pointers to NULL and parameters to
  * their 'not set' values

--- a/c/src/eval_ctx.c
+++ b/c/src/eval_ctx.c
@@ -94,6 +94,10 @@ plcs_errors plcs_eval_ctx_register_action(plcs_action_function_ptr action, plcs_
   return PLCS_ESUCCESS;
 }
 
+void plcs_eval_ctx_set_current_policy_id(const char *policy_id) {
+  ctx.current_policy_id = policy_id;
+}
+
 plcs_action_function_ptr plcs_eval_ctx_get_action(plcs_actions ix) {
   if (ix < 0 || ix >= PLCS_ACTIONS__COUNT) {
     ctx.error = PLCS_EIX_OVERFLOW;
@@ -212,6 +216,10 @@ plcs_errors plcs_eval_ctx_peek_last_error(void) {
   return ctx.error;
 }
 
+const char *plcs_eval_ctx_get_current_policy_id(void) {
+  return ctx.current_policy_id;
+}
+
 plcs_errors plcs_eval_ctx_get_last_error(void) {
   plcs_errors error = ctx.error;
   // reset
@@ -244,6 +252,7 @@ void plcs_eval_ctx_reset(void) {
   }
 
   ctx.error = PLCS_ESUCCESS;
+  ctx.current_policy_id = PLCS_STR_NOT_SET;
 }
 
 plcs_errors plcs_eval_ctx_init(void) {

--- a/c/src/eval_ctx.h
+++ b/c/src/eval_ctx.h
@@ -111,6 +111,9 @@ typedef struct plcs_eval_ctx {
   /**< TODO: consider implementing this as a stack to preserve history of errors */
   plcs_errors error;
 
+  /**< The id of the policy currently being evaluated */
+  const char *current_policy_id;
+
 } plcs_eval_ctx;
 
 /**
@@ -118,6 +121,12 @@ typedef struct plcs_eval_ctx {
  * @param error plcs_errors enum
  */
 void plcs_eval_ctx_set_error(plcs_errors error);
+
+/**
+ * @brief Sets the id of the policy currently being evaluated.
+ * @param policy_id the policy's id, or PLCS_STR_NOT_SET (NULL) if none.
+ */
+void plcs_eval_ctx_set_current_policy_id(const char *policy_id);
 
 /**
  * @brief Sets an error code for an action

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -289,6 +289,8 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
   plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
 
+  plcs_eval_ctx_set_current_policy_id(dd_ns(Policy_id)(policy));
+
   // perform actions given evaluation result
   return perform_actions(eval_res, actions);
 }

--- a/c/src/test/test_eval_ctx.c
+++ b/c/src/test/test_eval_ctx.c
@@ -298,6 +298,18 @@ UTEST(eval_ctx, last_error_set_and_get) {
   ASSERT_EQ(plcs_eval_ctx_peek_last_error(), (plcs_errors)PLCS_ESUCCESS);
 }
 
+UTEST(eval_ctx, current_policy_id_set_and_get) {
+  (void)plcs_eval_ctx_init();
+
+  ASSERT_TRUE(plcs_eval_ctx_get_current_policy_id() == PLCS_STR_NOT_SET);
+
+  plcs_eval_ctx_set_current_policy_id("some-policy-id");
+  ASSERT_STREQ(plcs_eval_ctx_get_current_policy_id(), "some-policy-id");
+
+  plcs_eval_ctx_reset();
+  ASSERT_TRUE(plcs_eval_ctx_get_current_policy_id() == PLCS_STR_NOT_SET);
+}
+
 UTEST(eval_ctx, set_error_out_of_bound) {
   plcs_eval_ctx_set_action_error(PLCS_ACTIONS__COUNT, 0);
   int err = plcs_eval_ctx_get_last_error();


### PR DESCRIPTION
This PR tracks the id of the policy currently being evaluated in the internal `eval_ctx` singleton, set just before its actions run, mirroring the existing `plcs_eval_ctx_get_last_error()` / `peek_last_error()` pattern.

A new public getter, `plcs_eval_ctx_get_current_policy_id()`, is added to `dd/policies/eval_ctx.h` for `auto_inject` to call from within an action callback.

## Testing
- [x] Built `dd-policy-engine.static-lib` and `dd-policy-engine.unit-tests` targets inside the CI docker image with no new warnings/errors
- [x] Added `eval_ctx.current_policy_id_set_and_get` test covering set/get/reset behavior
- [x] Ran full `ctest` suite: 56/56 passing