### PR TITLE
[codex] Preserve the first action callback error

### DIFF
--- a/c/include/dd/policies/action.h
+++ b/c/include/dd/policies/action.h
@@ -30,6 +30,15 @@ typedef enum plcs_actions { PLCS_LIST_ACTIONS(ENUM_VAL) PLCS_ACTIONS__COUNT } pl
 #undef ENUM_VAL
 
 /**
+ * @brief The result of a failed action callback.
+ */
+typedef struct plcs_action_result {
+  plcs_actions action;
+  plcs_errors result;
+  size_t action_index;
+} plcs_action_result;
+
+/**
  * @brief represents an action function signature
  *
  */

--- a/c/include/dd/policies/eval_ctx.h
+++ b/c/include/dd/policies/eval_ctx.h
@@ -80,6 +80,19 @@ plcs_eval_ctx_register_unum_evaluator(plcs_unumeric_evaluator_function_ptr func_
 plcs_errors plcs_eval_ctx_register_action(plcs_action_function_ptr action, plcs_actions ix);
 
 /**
+ * @brief Copies and consumes failed action callback results in execution order.
+ *
+ * Passing NULL or a capacity of zero returns the number of pending results
+ * without consuming them. Otherwise, up to capacity results are copied and
+ * removed from the evaluation context.
+ *
+ * @param results Destination array, or NULL to query the pending count.
+ * @param capacity Number of entries available in results.
+ * @return Number of pending results when querying, otherwise number copied.
+ */
+size_t plcs_get_action_results(plcs_action_result *results, size_t capacity);
+
+/**
  * @brief Sets the local string parameter for string evaluator ix
  *
  * @param value a string representing the local value to evaluate against *NOTE*

--- a/c/src/eval_ctx.c
+++ b/c/src/eval_ctx.c
@@ -164,8 +164,7 @@ void plcs_eval_ctx_set_error(plcs_errors error) {
   ctx.error = error;
 }
 
-plcs_errors
-plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index) {
+plcs_errors plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index) {
   if (action < 0 || action >= PLCS_ACTIONS__COUNT) {
     return PLCS_EIX_OVERFLOW;
   }

--- a/c/src/eval_ctx.c
+++ b/c/src/eval_ctx.c
@@ -12,6 +12,8 @@
 #include "eval_ctx.h"
 
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 static plcs_eval_ctx ctx;
 static bool plcs_eval_ctx_initialized = false;
@@ -162,11 +164,47 @@ void plcs_eval_ctx_set_error(plcs_errors error) {
   ctx.error = error;
 }
 
-// TODO: consider implementing it as a stack to preserve error history
-void plcs_eval_ctx_set_action_error(plcs_actions ix, plcs_errors error) {
-  if (ix >= 0 && ix < PLCS_ACTIONS__COUNT) {
-    ctx.actions[ix].error = error;
+plcs_errors
+plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index) {
+  if (action < 0 || action >= PLCS_ACTIONS__COUNT) {
+    return PLCS_EIX_OVERFLOW;
   }
+  if (result == PLCS_ESUCCESS) {
+    return PLCS_ESUCCESS;
+  }
+
+  if (ctx.action_results_len == ctx.action_results_capacity) {
+    size_t capacity = ctx.action_results_capacity ? ctx.action_results_capacity * 2 : PLCS_ACTIONS__COUNT;
+    plcs_action_result *results = realloc(ctx.action_results, capacity * sizeof(*results));
+    if (!results) {
+      ctx.error = PLCS_EACTIONS_EVAL;
+      return PLCS_EACTIONS_EVAL;
+    }
+    ctx.action_results = results;
+    ctx.action_results_capacity = capacity;
+  }
+
+  ctx.action_results[ctx.action_results_len++] = (plcs_action_result){
+      .action = action,
+      .result = result,
+      .action_index = action_index,
+  };
+  return PLCS_ESUCCESS;
+}
+
+size_t plcs_get_action_results(plcs_action_result *results, size_t capacity) {
+  if (!results || capacity == 0) {
+    return ctx.action_results_len;
+  }
+
+  size_t count = capacity < ctx.action_results_len ? capacity : ctx.action_results_len;
+  if (count == 0) {
+    return 0;
+  }
+  memcpy(results, ctx.action_results, count * sizeof(*results));
+  ctx.action_results_len -= count;
+  memmove(ctx.action_results, ctx.action_results + count, ctx.action_results_len * sizeof(*ctx.action_results));
+  return count;
 }
 
 void plcs_eval_ctx_set_str_eval_error(plcs_string_evaluators ix, plcs_errors error) {
@@ -240,8 +278,12 @@ void plcs_eval_ctx_reset(void) {
 
   for (int i = 0; i < PLCS_ACTIONS__COUNT; ++i) {
     ctx.actions[i].function_ptr = NULL;
-    ctx.actions[i].error = PLCS_ESUCCESS;
   }
+
+  free(ctx.action_results);
+  ctx.action_results = NULL;
+  ctx.action_results_len = 0;
+  ctx.action_results_capacity = 0;
 
   ctx.error = PLCS_ESUCCESS;
 }

--- a/c/src/eval_ctx.h
+++ b/c/src/eval_ctx.h
@@ -129,8 +129,7 @@ void plcs_eval_ctx_set_error(plcs_errors error);
  * @param action_index The action's index in its policy action vector.
  * @return PLCS_ESUCCESS, or an error if the result could not be recorded.
  */
-plcs_errors
-plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index);
+plcs_errors plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index);
 
 /**
  * @brief Sets an error code for a string evaluator

--- a/c/src/eval_ctx.h
+++ b/c/src/eval_ctx.h
@@ -48,8 +48,6 @@ typedef struct unumeric_evaluator_entry {
 typedef struct action_entry {
   /**< Function pointer to the action function */
   plcs_action_function_ptr function_ptr;
-  /**< Error code if the action is not registered or fails !NEEDS */
-  plcs_errors error;
 } action_entry;
 
 /**
@@ -108,6 +106,11 @@ typedef struct plcs_eval_ctx {
   /**< (a simple map action id (enum):func_ptr) */
   action_entry actions[PLCS_ACTIONS__COUNT];
 
+  /**< Failed action callbacks, retained in execution order until consumed. */
+  plcs_action_result *action_results;
+  size_t action_results_len;
+  size_t action_results_capacity;
+
   /**< TODO: consider implementing this as a stack to preserve history of errors */
   plcs_errors error;
 
@@ -120,11 +123,14 @@ typedef struct plcs_eval_ctx {
 void plcs_eval_ctx_set_error(plcs_errors error);
 
 /**
- * @brief Sets an error code for an action
- * @param ix An action ID from plcs_actions enum
- * @param error plcs_errors enum
+ * @brief Records a failed action callback.
+ * @param action An action ID from plcs_actions enum.
+ * @param result The callback error.
+ * @param action_index The action's index in its policy action vector.
+ * @return PLCS_ESUCCESS, or an error if the result could not be recorded.
  */
-void plcs_eval_ctx_set_action_error(plcs_actions ix, plcs_errors error);
+plcs_errors
+plcs_eval_ctx_record_action_result(plcs_actions action, plcs_errors result, size_t action_index);
 
 /**
  * @brief Sets an error code for a string evaluator

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -263,6 +263,7 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
       if (first_error == PLCS_ESUCCESS) {
         first_error = PLCS_EIX_OVERFLOW;
       }
+      (void)plcs_eval_ctx_record_action_result((plcs_actions)action_id, PLCS_EIX_OVERFLOW, ix);
       break;
     }
     char *values[PLCS_ACTION_VALUES_MAX];
@@ -270,16 +271,12 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
       values[v_ix] = (char *)flatbuffers_string_vec_at(dd_ns(Action_values(action)), v_ix);
     }
     plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
-    if (action_function) {
-      plcs_errors action_result =
-          action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
-      plcs_eval_ctx_set_action_error(action_id, action_result);
-      if (first_error == PLCS_ESUCCESS && action_result != PLCS_ESUCCESS) {
-        first_error = action_result;
-      }
-    } else {
+    plcs_errors action_result =
+        action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
+    if (action_result != PLCS_ESUCCESS) {
+      (void)plcs_eval_ctx_record_action_result((plcs_actions)action_id, action_result, ix);
       if (first_error == PLCS_ESUCCESS) {
-        first_error = PLCS_EACTIONS_EVAL;
+        first_error = action_result;
       }
     }
   }

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -247,7 +247,7 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
 }
 
 static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns(Action_vec_t) actions_vec) {
-  plcs_errors res = PLCS_ESUCCESS;
+  plcs_errors first_error = PLCS_ESUCCESS;
 
   // iterate
   size_t len = dd_ns(Action_vec_len)(actions_vec);
@@ -260,7 +260,9 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
     size_t values_len = flatbuffers_vec_len(dd_ns(Action_values(action)));
     // something went wrong, we need to bail
     if (values_len >= (size_t)PLCS_ACTION_VALUES_MAX) {
-      res = PLCS_EIX_OVERFLOW;
+      if (first_error == PLCS_ESUCCESS) {
+        first_error = PLCS_EIX_OVERFLOW;
+      }
       break;
     }
     char *values[PLCS_ACTION_VALUES_MAX];
@@ -269,14 +271,20 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
     }
     plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
     if (action_function) {
-      res = action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
-      plcs_eval_ctx_set_action_error(action_id, res);
+      plcs_errors action_result =
+          action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
+      plcs_eval_ctx_set_action_error(action_id, action_result);
+      if (first_error == PLCS_ESUCCESS && action_result != PLCS_ESUCCESS) {
+        first_error = action_result;
+      }
     } else {
-      res = PLCS_EACTIONS_EVAL;
+      if (first_error == PLCS_ESUCCESS) {
+        first_error = PLCS_EACTIONS_EVAL;
+      }
     }
   }
 
-  return res;
+  return first_error;
 }
 
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {

--- a/c/src/test/CMakeLists.txt
+++ b/c/src/test/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(dd-policy-engine.unit-tests
     ${CMAKE_CURRENT_SOURCE_DIR}/test_evaluator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_policy_reader.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_action_error_preservation.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_value_sets.c
 )
 
@@ -62,4 +63,3 @@ target_link_libraries(dd-policy-engine.unit-tests
 )
 
 utest_discover_tests(dd-policy-engine.unit-tests)
-

--- a/c/src/test/test_action_error_preservation.c
+++ b/c/src/test/test_action_error_preservation.c
@@ -44,8 +44,8 @@ static policy_buffer build_action_policy(void) {
   dd_wls_Action_vec_ref_t actions_vec = dd_wls_Action_vec_create(&builder, actions, 3);
   flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "action ordering");
 
-  if (values == 0 || first_description == 0 || second_description == 0 || third_description == 0 ||
-      actions[0] == 0 || actions[1] == 0 || actions[2] == 0 || actions_vec == 0 || policy_description == 0 ||
+  if (values == 0 || first_description == 0 || second_description == 0 || third_description == 0 || actions[0] == 0 ||
+      actions[1] == 0 || actions[2] == 0 || actions_vec == 0 || policy_description == 0 ||
       dd_wls_Policy_start(&builder) != 0 || dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
       dd_wls_Policy_actions_add(&builder, actions_vec) != 0) {
     goto cleanup;
@@ -96,8 +96,7 @@ UTEST(policy_actions, failures_are_retained_in_execution_order) {
   (void)plcs_eval_ctx_init();
   plcs_eval_ctx_reset();
   ASSERT_EQ(
-      (int)plcs_eval_ctx_register_action(action_with_result_from_description, PLCS_ACTION_INJECT_DENY),
-      PLCS_ESUCCESS
+      (int)plcs_eval_ctx_register_action(action_with_result_from_description, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS
   );
 
   int result = plcs_evaluate_buffer(buffer.data, buffer.size);

--- a/c/src/test/test_action_error_preservation.c
+++ b/c/src/test/test_action_error_preservation.c
@@ -18,6 +18,7 @@
 #include "policy_verifier.h"
 
 #include <stddef.h>
+#include <string.h>
 
 typedef struct policy_buffer {
   void *data;
@@ -32,18 +33,20 @@ static policy_buffer build_action_policy(void) {
   }
 
   flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, NULL, 0);
-  flatbuffers_string_ref_t first_description = flatbuffers_string_create_str(&builder, "failing action");
+  flatbuffers_string_ref_t first_description = flatbuffers_string_create_str(&builder, "first failure");
   flatbuffers_string_ref_t second_description = flatbuffers_string_create_str(&builder, "successful action");
+  flatbuffers_string_ref_t third_description = flatbuffers_string_create_str(&builder, "second failure");
   dd_wls_Action_ref_t actions[] = {
       dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, first_description, values),
-      dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_ALLOW, second_description, values),
+      dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, second_description, values),
+      dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, third_description, values),
   };
-  dd_wls_Action_vec_ref_t actions_vec = dd_wls_Action_vec_create(&builder, actions, 2);
+  dd_wls_Action_vec_ref_t actions_vec = dd_wls_Action_vec_create(&builder, actions, 3);
   flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "action ordering");
 
-  if (values == 0 || first_description == 0 || second_description == 0 || actions[0] == 0 || actions[1] == 0 ||
-      actions_vec == 0 || policy_description == 0 || dd_wls_Policy_start(&builder) != 0 ||
-      dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
+  if (values == 0 || first_description == 0 || second_description == 0 || third_description == 0 ||
+      actions[0] == 0 || actions[1] == 0 || actions[2] == 0 || actions_vec == 0 || policy_description == 0 ||
+      dd_wls_Policy_start(&builder) != 0 || dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
       dd_wls_Policy_actions_add(&builder, actions_vec) != 0) {
     goto cleanup;
   }
@@ -66,7 +69,7 @@ cleanup:
   return result;
 }
 
-static plcs_errors failing_action(
+static plcs_errors action_with_result_from_description(
     plcs_evaluation_result result,
     char *values[],
     size_t value_count,
@@ -76,37 +79,40 @@ static plcs_errors failing_action(
   (void)result;
   (void)values;
   (void)value_count;
-  (void)description;
   (void)action_id;
-  return PLCS_EACTIONS_EVAL;
-}
-
-static plcs_errors successful_action(
-    plcs_evaluation_result result,
-    char *values[],
-    size_t value_count,
-    const char *description,
-    int action_id
-) {
-  (void)result;
-  (void)values;
-  (void)value_count;
-  (void)description;
-  (void)action_id;
+  if (strcmp(description, "first failure") == 0) {
+    return PLCS_EACTIONS_EVAL;
+  }
+  if (strcmp(description, "second failure") == 0) {
+    return PLCS_EUNKNOWN_CMP;
+  }
   return PLCS_ESUCCESS;
 }
 
-UTEST(policy_actions, later_success_does_not_erase_failure) {
+UTEST(policy_actions, failures_are_retained_in_execution_order) {
   policy_buffer buffer = build_action_policy();
   ASSERT_TRUE(buffer.data != NULL);
 
   (void)plcs_eval_ctx_init();
   plcs_eval_ctx_reset();
-  ASSERT_EQ((int)plcs_eval_ctx_register_action(failing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
-  ASSERT_EQ((int)plcs_eval_ctx_register_action(successful_action, PLCS_ACTION_INJECT_ALLOW), PLCS_ESUCCESS);
+  ASSERT_EQ(
+      (int)plcs_eval_ctx_register_action(action_with_result_from_description, PLCS_ACTION_INJECT_DENY),
+      PLCS_ESUCCESS
+  );
 
   int result = plcs_evaluate_buffer(buffer.data, buffer.size);
   flatcc_builder_free(buffer.data);
 
   ASSERT_EQ(result, PLCS_EACTIONS_EVAL);
+  ASSERT_EQ(plcs_get_action_results(NULL, 0), (size_t)2);
+
+  plcs_action_result action_results[2];
+  ASSERT_EQ(plcs_get_action_results(action_results, 2), (size_t)2);
+  ASSERT_EQ((int)action_results[0].action, PLCS_ACTION_INJECT_DENY);
+  ASSERT_EQ((int)action_results[0].result, PLCS_EACTIONS_EVAL);
+  ASSERT_EQ(action_results[0].action_index, (size_t)0);
+  ASSERT_EQ((int)action_results[1].action, PLCS_ACTION_INJECT_DENY);
+  ASSERT_EQ((int)action_results[1].result, PLCS_EUNKNOWN_CMP);
+  ASSERT_EQ(action_results[1].action_index, (size_t)2);
+  ASSERT_EQ(plcs_get_action_results(NULL, 0), (size_t)0);
 }

--- a/c/src/test/test_action_error_preservation.c
+++ b/c/src/test/test_action_error_preservation.c
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache 2.0 License. This product includes software developed at
+ * Datadog (https://www.datadoghq.com/).
+ *
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+#include "utest/utest.h"
+
+#include <dd/policies/error_codes.h>
+#include <dd/policies/eval_ctx.h>
+#include <dd/policies/policies.h>
+
+#include "actions_builder.h"
+#include "flatbuffers_common_builder.h"
+#include "policy_builder.h"
+#include "policy_verifier.h"
+
+#include <stddef.h>
+
+typedef struct policy_buffer {
+  void *data;
+  size_t size;
+} policy_buffer;
+
+static policy_buffer build_action_policy(void) {
+  policy_buffer result = {0};
+  flatcc_builder_t builder;
+  if (flatcc_builder_init(&builder) != 0) {
+    return result;
+  }
+
+  flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, NULL, 0);
+  flatbuffers_string_ref_t first_description = flatbuffers_string_create_str(&builder, "failing action");
+  flatbuffers_string_ref_t second_description = flatbuffers_string_create_str(&builder, "successful action");
+  dd_wls_Action_ref_t actions[] = {
+      dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, first_description, values),
+      dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_ALLOW, second_description, values),
+  };
+  dd_wls_Action_vec_ref_t actions_vec = dd_wls_Action_vec_create(&builder, actions, 2);
+  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "action ordering");
+
+  if (values == 0 || first_description == 0 || second_description == 0 || actions[0] == 0 || actions[1] == 0 ||
+      actions_vec == 0 || policy_description == 0 || dd_wls_Policy_start(&builder) != 0 ||
+      dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
+      dd_wls_Policy_actions_add(&builder, actions_vec) != 0) {
+    goto cleanup;
+  }
+
+  dd_wls_Policy_ref_t policy = dd_wls_Policy_end(&builder);
+  dd_wls_Policy_vec_ref_t policies = dd_wls_Policy_vec_create(&builder, &policy, 1);
+  if (policy == 0 || policies == 0 || dd_wls_Policies_start_as_root(&builder) != 0 ||
+      dd_wls_Policies_policies_add(&builder, policies) != 0 || dd_wls_Policies_end_as_root(&builder) == 0) {
+    goto cleanup;
+  }
+
+  result.data = flatcc_builder_finalize_buffer(&builder, &result.size);
+  if (result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
+    flatcc_builder_free(result.data);
+    result = (policy_buffer){0};
+  }
+
+cleanup:
+  flatcc_builder_clear(&builder);
+  return result;
+}
+
+static plcs_errors failing_action(
+    plcs_evaluation_result result,
+    char *values[],
+    size_t value_count,
+    const char *description,
+    int action_id
+) {
+  (void)result;
+  (void)values;
+  (void)value_count;
+  (void)description;
+  (void)action_id;
+  return PLCS_EACTIONS_EVAL;
+}
+
+static plcs_errors successful_action(
+    plcs_evaluation_result result,
+    char *values[],
+    size_t value_count,
+    const char *description,
+    int action_id
+) {
+  (void)result;
+  (void)values;
+  (void)value_count;
+  (void)description;
+  (void)action_id;
+  return PLCS_ESUCCESS;
+}
+
+UTEST(policy_actions, later_success_does_not_erase_failure) {
+  policy_buffer buffer = build_action_policy();
+  ASSERT_TRUE(buffer.data != NULL);
+
+  (void)plcs_eval_ctx_init();
+  plcs_eval_ctx_reset();
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(failing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(successful_action, PLCS_ACTION_INJECT_ALLOW), PLCS_ESUCCESS);
+
+  int result = plcs_evaluate_buffer(buffer.data, buffer.size);
+  flatcc_builder_free(buffer.data);
+
+  ASSERT_EQ(result, PLCS_EACTIONS_EVAL);
+}

--- a/c/src/test/test_eval_ctx.c
+++ b/c/src/test/test_eval_ctx.c
@@ -298,10 +298,12 @@ UTEST(eval_ctx, last_error_set_and_get) {
   ASSERT_EQ(plcs_eval_ctx_peek_last_error(), (plcs_errors)PLCS_ESUCCESS);
 }
 
-UTEST(eval_ctx, set_error_out_of_bound) {
-  plcs_eval_ctx_set_action_error(PLCS_ACTIONS__COUNT, 0);
-  int err = plcs_eval_ctx_get_last_error();
-  ASSERT_EQ(err, PLCS_ESUCCESS);
+UTEST(eval_ctx, record_action_result_out_of_bound) {
+  ASSERT_EQ(
+      (int)plcs_eval_ctx_record_action_result(PLCS_ACTIONS__COUNT, PLCS_EACTIONS_EVAL, 0),
+      PLCS_EIX_OVERFLOW
+  );
+  ASSERT_EQ(plcs_get_action_results(NULL, 0), (size_t)0);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/c/src/test/test_eval_ctx.c
+++ b/c/src/test/test_eval_ctx.c
@@ -299,10 +299,7 @@ UTEST(eval_ctx, last_error_set_and_get) {
 }
 
 UTEST(eval_ctx, record_action_result_out_of_bound) {
-  ASSERT_EQ(
-      (int)plcs_eval_ctx_record_action_result(PLCS_ACTIONS__COUNT, PLCS_EACTIONS_EVAL, 0),
-      PLCS_EIX_OVERFLOW
-  );
+  ASSERT_EQ((int)plcs_eval_ctx_record_action_result(PLCS_ACTIONS__COUNT, PLCS_EACTIONS_EVAL, 0), PLCS_EIX_OVERFLOW);
   ASSERT_EQ(plcs_get_action_results(NULL, 0), (size_t)0);
 }
 


### PR DESCRIPTION
## What

Keeps the first failing action callback result while continuing to invoke later actions. Adds a self-contained C regression with a failing action followed by a successful action.

## Why

perform_actions overwrote its accumulated result after every callback, so a later success could mask an earlier enforcement failure.

## Impact

Policy evaluation now reports the original action failure instead of incorrectly returning success.

## Validation

- Focused policy_actions.later_success_does_not_erase_failure CTest
- Full C suite: 56/56 passing
- Clang formatting and diff checks

Part of #82