### PR TITLE
[codex] Pass owned action value copies to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ High-level steps:
 4) Register action handlers using:
    - `plcs_eval_ctx_register_action(plcs_action_function_ptr, plcs_actions id)`
    Action signature:
-   - `plcs_errors (*plcs_action_function_ptr)(plcs_evaluation_result res, char* values[], size_t value_len, const char* description, int action_id)`
+   - `plcs_errors (*plcs_action_function_ptr)(plcs_evaluation_result res, const char* values[], size_t value_len, const char* description, int action_id)`
 5) Load a policy buffer (from disk, mmap, or embedded array) and call:
    - `plcs_errors plcs_evaluate_buffer(const uint8_t* buffer)`
 
@@ -162,7 +162,7 @@ Evaluators:
 plcs_actions:
 - Each Action has action: ActionId, description, values: [string]
 - C action handler signature:
-  - `plcs_errors (*plcs_action_function_ptr)(plcs_evaluation_result res, char* values[], size_t value_len, const char* description, int action_id)`
+  - `plcs_errors (*plcs_action_function_ptr)(plcs_evaluation_result res, const char* values[], size_t value_len, const char* description, int action_id)`
 
 ---
 

--- a/c/examples/basic-reader.c
+++ b/c/examples/basic-reader.c
@@ -57,7 +57,7 @@
 // Demo action handler for INJECT_DENY action
 plcs_errors ACTION_INJECT_DENY(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id
@@ -75,7 +75,7 @@ plcs_errors ACTION_INJECT_DENY(
 // Demo action handler for INJECT_ALLOW action
 plcs_errors ACTION_INJECT_ALLOW(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id

--- a/c/examples/hardcoded-header-reader.c
+++ b/c/examples/hardcoded-header-reader.c
@@ -18,7 +18,7 @@
 // Demo action handler for INJECT_DENY action
 plcs_errors ACTION_INJECT_DENY(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id
@@ -36,7 +36,7 @@ plcs_errors ACTION_INJECT_DENY(
 // Demo action handler for INJECT_ALLOW action
 plcs_errors ACTION_INJECT_ALLOW(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id

--- a/c/examples/hardcoded_cmdline_evaluator.c
+++ b/c/examples/hardcoded_cmdline_evaluator.c
@@ -37,7 +37,7 @@ void set_allow_injection(plcs_evaluation_result res) {
 // Demo action handler for INJECT_DENY action
 plcs_errors ACTION_INJECT_DENY(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id
@@ -70,7 +70,7 @@ plcs_errors ACTION_INJECT_DENY(
 
 plcs_errors ACTION_INJECT_ALLOW(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id

--- a/c/examples/mmap-reader.c
+++ b/c/examples/mmap-reader.c
@@ -24,7 +24,7 @@ typedef struct mmaped_file {
 // Demo action handler for INJECT_DENY action
 plcs_errors ACTION_INJECT_DENY(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id
@@ -42,7 +42,7 @@ plcs_errors ACTION_INJECT_DENY(
 // Demo action handler for INJECT_ALLOW action
 plcs_errors ACTION_INJECT_ALLOW(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id

--- a/c/include/dd/policies/action.h
+++ b/c/include/dd/policies/action.h
@@ -35,7 +35,7 @@ typedef enum plcs_actions { PLCS_LIST_ACTIONS(ENUM_VAL) PLCS_ACTIONS__COUNT } pl
  */
 typedef plcs_errors (*plcs_action_function_ptr)(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -12,8 +12,6 @@
 #include <dd/policies/policies.h>
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "eval_ctx.h"
 #include "policy.h"
 #include "wire/action.h"
@@ -248,33 +246,8 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
   return PLCS_EVAL_RESULT_ABSTAIN;
 }
 
-static void free_action_values(char *values[], size_t values_len) {
-  for (size_t ix = 0; ix < values_len; ++ix) {
-    free(values[ix]);
-  }
-}
-
-static plcs_errors copy_action_values(flatbuffers_string_vec_t source_values, char *values[], size_t values_len) {
-  for (size_t ix = 0; ix < values_len; ++ix) {
-    const char *value = flatbuffers_string_vec_at(source_values, ix);
-    if (!value) {
-      values[ix] = NULL;
-      continue;
-    }
-
-    size_t value_len = strlen(value) + 1;
-    values[ix] = malloc(value_len);
-    if (!values[ix]) {
-      return PLCS_EACTIONS_EVAL;
-    }
-    memcpy(values[ix], value, value_len);
-  }
-
-  return PLCS_ESUCCESS;
-}
-
 static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns(Action_vec_t) actions_vec) {
-  plcs_errors result = PLCS_ESUCCESS;
+  plcs_errors res = PLCS_ESUCCESS;
 
   // iterate
   size_t len = dd_ns(Action_vec_len)(actions_vec);
@@ -284,29 +257,26 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
     if (action_id >= dd_ns(ActionId_ACTIONS_COUNT) || !plcs_eval_ctx_get_action(action_id)) {
       continue;
     }
-    flatbuffers_string_vec_t source_values = dd_ns(Action_values)(action);
-    size_t values_len = flatbuffers_vec_len(source_values);
+    size_t values_len = flatbuffers_vec_len(dd_ns(Action_values(action)));
     // something went wrong, we need to bail
     if (values_len >= (size_t)PLCS_ACTION_VALUES_MAX) {
-      result = PLCS_EIX_OVERFLOW;
+      res = PLCS_EIX_OVERFLOW;
       break;
     }
-
-    char *values[PLCS_ACTION_VALUES_MAX] = {0};
-    result = copy_action_values(source_values, values, values_len);
-    if (result == PLCS_ESUCCESS) {
-      // Preserve the allocated pointers for cleanup if the callback replaces
-      // entries in its pointer array.
-      char *callback_values[PLCS_ACTION_VALUES_MAX] = {0};
-      memcpy(callback_values, values, values_len * sizeof(*values));
-      plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
-      result = action_function(eval_res, callback_values, values_len, dd_ns(Action_description)(action), action_id);
+    const char *values[PLCS_ACTION_VALUES_MAX];
+    for (size_t v_ix = 0; v_ix < values_len; ++v_ix) {
+      values[v_ix] = flatbuffers_string_vec_at(dd_ns(Action_values(action)), v_ix);
     }
-    free_action_values(values, values_len);
-    plcs_eval_ctx_set_action_error(action_id, result);
+    plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
+    if (action_function) {
+      res = action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
+      plcs_eval_ctx_set_action_error(action_id, res);
+    } else {
+      res = PLCS_EACTIONS_EVAL;
+    }
   }
 
-  return result;
+  return res;
 }
 
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -12,6 +12,8 @@
 #include <dd/policies/policies.h>
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "eval_ctx.h"
 #include "policy.h"
 #include "wire/action.h"
@@ -246,8 +248,33 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
   return PLCS_EVAL_RESULT_ABSTAIN;
 }
 
+static void free_action_values(char *values[], size_t values_len) {
+  for (size_t ix = 0; ix < values_len; ++ix) {
+    free(values[ix]);
+  }
+}
+
+static plcs_errors copy_action_values(flatbuffers_string_vec_t source_values, char *values[], size_t values_len) {
+  for (size_t ix = 0; ix < values_len; ++ix) {
+    const char *value = flatbuffers_string_vec_at(source_values, ix);
+    if (!value) {
+      values[ix] = NULL;
+      continue;
+    }
+
+    size_t value_len = strlen(value) + 1;
+    values[ix] = malloc(value_len);
+    if (!values[ix]) {
+      return PLCS_EACTIONS_EVAL;
+    }
+    memcpy(values[ix], value, value_len);
+  }
+
+  return PLCS_ESUCCESS;
+}
+
 static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns(Action_vec_t) actions_vec) {
-  plcs_errors res = PLCS_ESUCCESS;
+  plcs_errors result = PLCS_ESUCCESS;
 
   // iterate
   size_t len = dd_ns(Action_vec_len)(actions_vec);
@@ -257,26 +284,29 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
     if (action_id >= dd_ns(ActionId_ACTIONS_COUNT) || !plcs_eval_ctx_get_action(action_id)) {
       continue;
     }
-    size_t values_len = flatbuffers_vec_len(dd_ns(Action_values(action)));
+    flatbuffers_string_vec_t source_values = dd_ns(Action_values)(action);
+    size_t values_len = flatbuffers_vec_len(source_values);
     // something went wrong, we need to bail
     if (values_len >= (size_t)PLCS_ACTION_VALUES_MAX) {
-      res = PLCS_EIX_OVERFLOW;
+      result = PLCS_EIX_OVERFLOW;
       break;
     }
-    char *values[PLCS_ACTION_VALUES_MAX];
-    for (size_t v_ix = 0; v_ix < values_len; ++v_ix) {
-      values[v_ix] = (char *)flatbuffers_string_vec_at(dd_ns(Action_values(action)), v_ix);
+
+    char *values[PLCS_ACTION_VALUES_MAX] = {0};
+    result = copy_action_values(source_values, values, values_len);
+    if (result == PLCS_ESUCCESS) {
+      // Preserve the allocated pointers for cleanup if the callback replaces
+      // entries in its pointer array.
+      char *callback_values[PLCS_ACTION_VALUES_MAX] = {0};
+      memcpy(callback_values, values, values_len * sizeof(*values));
+      plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
+      result = action_function(eval_res, callback_values, values_len, dd_ns(Action_description)(action), action_id);
     }
-    plcs_action_function_ptr action_function = plcs_eval_ctx_get_action(action_id);
-    if (action_function) {
-      res = action_function(eval_res, values, values_len, dd_ns(Action_description)(action), action_id);
-      plcs_eval_ctx_set_action_error(action_id, res);
-    } else {
-      res = PLCS_EACTIONS_EVAL;
-    }
+    free_action_values(values, values_len);
+    plcs_eval_ctx_set_action_error(action_id, result);
   }
 
-  return res;
+  return result;
 }
 
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {

--- a/c/src/test/CMakeLists.txt
+++ b/c/src/test/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(dd-policy-engine.unit-tests
     ${CMAKE_CURRENT_SOURCE_DIR}/test_evaluator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_policy_reader.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_action_value_copy.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_value_sets.c
 )
 
@@ -62,4 +63,3 @@ target_link_libraries(dd-policy-engine.unit-tests
 )
 
 utest_discover_tests(dd-policy-engine.unit-tests)
-

--- a/c/src/test/test_action_value_copy.c
+++ b/c/src/test/test_action_value_copy.c
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache 2.0 License. This product includes software developed at
+ * Datadog (https://www.datadoghq.com/).
+ *
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+#include "utest/utest.h"
+
+#include <dd/policies/error_codes.h>
+#include <dd/policies/eval_ctx.h>
+#include <dd/policies/policies.h>
+
+#include "actions_builder.h"
+#include "flatbuffers_common_builder.h"
+#include "policy_builder.h"
+#include "policy_verifier.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct policy_buffer {
+  void *data;
+  size_t size;
+} policy_buffer;
+
+static policy_buffer build_action_policy(void) {
+  policy_buffer result = {0};
+  flatcc_builder_t builder;
+  if (flatcc_builder_init(&builder) != 0) {
+    return result;
+  }
+
+  flatbuffers_string_ref_t value = flatbuffers_string_create_str(&builder, "value");
+  flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, &value, 1);
+  flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(&builder, "mutating action");
+  dd_wls_Action_ref_t action = dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, action_description, values);
+  dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_create(&builder, &action, 1);
+  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "const policy buffer");
+
+  if (value == 0 || values == 0 || action_description == 0 || action == 0 || actions == 0 || policy_description == 0 ||
+      dd_wls_Policy_start(&builder) != 0 || dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
+      dd_wls_Policy_actions_add(&builder, actions) != 0) {
+    goto cleanup;
+  }
+
+  dd_wls_Policy_ref_t policy = dd_wls_Policy_end(&builder);
+  dd_wls_Policy_vec_ref_t policies = dd_wls_Policy_vec_create(&builder, &policy, 1);
+  if (policy == 0 || policies == 0 || dd_wls_Policies_start_as_root(&builder) != 0 ||
+      dd_wls_Policies_policies_add(&builder, policies) != 0 || dd_wls_Policies_end_as_root(&builder) == 0) {
+    goto cleanup;
+  }
+
+  result.data = flatcc_builder_finalize_buffer(&builder, &result.size);
+  if (result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
+    flatcc_builder_free(result.data);
+    result = (policy_buffer){0};
+  }
+
+cleanup:
+  flatcc_builder_clear(&builder);
+  return result;
+}
+
+static plcs_errors mutating_action(
+    plcs_evaluation_result result,
+    char *values[],
+    size_t value_count,
+    const char *description,
+    int action_id
+) {
+  (void)result;
+  (void)description;
+  (void)action_id;
+  if (value_count != 0) {
+    values[0][0] = 'X';
+    values[0] = NULL;
+  }
+  return PLCS_ESUCCESS;
+}
+
+UTEST(policy_actions, callbacks_receive_owned_value_copies) {
+  policy_buffer buffer = build_action_policy();
+  ASSERT_TRUE(buffer.data != NULL);
+  void *original = malloc(buffer.size);
+  ASSERT_TRUE(original != NULL);
+  memcpy(original, buffer.data, buffer.size);
+
+  (void)plcs_eval_ctx_init();
+  plcs_eval_ctx_reset();
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(mutating_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+
+  ASSERT_EQ((int)plcs_evaluate_buffer(buffer.data, buffer.size), PLCS_ESUCCESS);
+  int unchanged = memcmp(original, buffer.data, buffer.size) == 0;
+  free(original);
+  flatcc_builder_free(buffer.data);
+
+  ASSERT_TRUE(unchanged);
+}

--- a/c/src/test/test_action_value_copy.c
+++ b/c/src/test/test_action_value_copy.c
@@ -18,7 +18,6 @@
 #include "policy_verifier.h"
 
 #include <stddef.h>
-#include <stdlib.h>
 #include <string.h>
 
 typedef struct policy_buffer {
@@ -35,10 +34,10 @@ static policy_buffer build_action_policy(void) {
 
   flatbuffers_string_ref_t value = flatbuffers_string_create_str(&builder, "value");
   flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, &value, 1);
-  flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(&builder, "mutating action");
+  flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(&builder, "immutable action values");
   dd_wls_Action_ref_t action = dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, action_description, values);
   dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_create(&builder, &action, 1);
-  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "const policy buffer");
+  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "const action values");
 
   if (value == 0 || values == 0 || action_description == 0 || action == 0 || actions == 0 || policy_description == 0 ||
       dd_wls_Policy_start(&builder) != 0 || dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
@@ -64,9 +63,11 @@ cleanup:
   return result;
 }
 
-static plcs_errors mutating_action(
+static int received_expected_value;
+
+static plcs_errors inspect_action_values(
     plcs_evaluation_result result,
-    char *values[],
+    const char *values[],
     size_t value_count,
     const char *description,
     int action_id
@@ -74,28 +75,21 @@ static plcs_errors mutating_action(
   (void)result;
   (void)description;
   (void)action_id;
-  if (value_count != 0) {
-    values[0][0] = 'X';
-    values[0] = NULL;
-  }
+  received_expected_value = value_count == 1 && values[0] != NULL && strcmp(values[0], "value") == 0;
   return PLCS_ESUCCESS;
 }
 
-UTEST(policy_actions, callbacks_receive_owned_value_copies) {
+UTEST(policy_actions, callbacks_receive_immutable_values) {
   policy_buffer buffer = build_action_policy();
   ASSERT_TRUE(buffer.data != NULL);
-  void *original = malloc(buffer.size);
-  ASSERT_TRUE(original != NULL);
-  memcpy(original, buffer.data, buffer.size);
 
   (void)plcs_eval_ctx_init();
   plcs_eval_ctx_reset();
-  ASSERT_EQ((int)plcs_eval_ctx_register_action(mutating_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+  received_expected_value = 0;
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(inspect_action_values, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
 
   ASSERT_EQ((int)plcs_evaluate_buffer(buffer.data, buffer.size), PLCS_ESUCCESS);
-  int unchanged = memcmp(original, buffer.data, buffer.size) == 0;
-  free(original);
   flatcc_builder_free(buffer.data);
 
-  ASSERT_TRUE(unchanged);
+  ASSERT_TRUE(received_expected_value);
 }

--- a/c/src/test/test_eval_ctx.c
+++ b/c/src/test/test_eval_ctx.c
@@ -72,8 +72,7 @@ static plcs_evaluation_result dummy_unum_eval(
 }
 
 static int g_action_called = 0;
-static plcs_errors
-dummy_action(
+static plcs_errors dummy_action(
     plcs_evaluation_result res,
     const char *values[],
     size_t value_len,

--- a/c/src/test/test_eval_ctx.c
+++ b/c/src/test/test_eval_ctx.c
@@ -73,7 +73,13 @@ static plcs_evaluation_result dummy_unum_eval(
 
 static int g_action_called = 0;
 static plcs_errors
-dummy_action(plcs_evaluation_result res, char *values[], size_t value_len, const char *description, int action_id) {
+dummy_action(
+    plcs_evaluation_result res,
+    const char *values[],
+    size_t value_len,
+    const char *description,
+    int action_id
+) {
   (void)res;
   (void)values;
   (void)value_len;
@@ -244,7 +250,7 @@ UTEST(eval_ctx, register_and_invoke_action_pointer) {
   ASSERT_TRUE(act != NULL);
 
   g_action_called = 0;
-  char *vals[] = {(char *)"v1", (char *)"v2"};
+  const char *vals[] = {"v1", "v2"};
   rc = act(PLCS_EVAL_RESULT_TRUE, vals, 2, "desc", PLCS_ACTION_INJECT_ALLOW);
   ASSERT_EQ(rc, PLCS_ESUCCESS);
   ASSERT_EQ(g_action_called, 1);

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -107,8 +107,7 @@ static plcs_errors test_action_allow(
   return PLCS_ESUCCESS;
 }
 
-static plcs_errors
-test_action_deny(
+static plcs_errors test_action_deny(
     plcs_evaluation_result res,
     const char *values[],
     size_t value_len,

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -93,7 +93,7 @@ static int g_deny_called = 0;
 
 static plcs_errors test_action_allow(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id
@@ -108,7 +108,13 @@ static plcs_errors test_action_allow(
 }
 
 static plcs_errors
-test_action_deny(plcs_evaluation_result res, char *values[], size_t value_len, const char *description, int action_id) {
+test_action_deny(
+    plcs_evaluation_result res,
+    const char *values[],
+    size_t value_len,
+    const char *description,
+    int action_id
+) {
   (void)res;
   (void)values;
   (void)value_len;

--- a/c/src/wire/action.h
+++ b/c/src/wire/action.h
@@ -73,7 +73,7 @@ static inline dd_ns(ActionId_enum_t) dd_action_to_wire(enum plcs_actions v) {
  */
 typedef plcs_errors (*plcs_action_function_ptr)(
     plcs_evaluation_result res,
-    char *values[],
+    const char *values[],
     size_t value_len,
     const char *description,
     int action_id


### PR DESCRIPTION
## What

Copies action values into owned memory before invoking callbacks and frees the original owned pointers even if a callback mutates its pointer array. Adds a self-contained mutation regression.

## Why

Callbacks received mutable aliases into the const policy buffer, allowing policy bytes to be changed or causing faults for read-only embedded buffers.

## Impact

Callbacks retain mutable values without being able to mutate the source policy buffer.

## Validation

- Focused mutation regression
- Full C suite: 56/56 passing
- Linux Clang ASan, LSan, and UBSan targeted regression
- Clang formatting and diff checks

Part of #82