### PR TITLE
[codex] Reject invalid boolean operators

### DIFF
--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -11,6 +11,7 @@
 #include <dd/policies/evaluator_default.h>
 #include <dd/policies/policies.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include "eval_ctx.h"
 #include "policy.h"
@@ -19,6 +20,13 @@
 #include "wire/dd_types.h"
 #include "wire/evaluation_result.h"
 #define PLCS_MAX_EVAL_DEPTH 64
+
+typedef struct rule_evaluation {
+  plcs_evaluation_result result;
+  plcs_errors error;
+} rule_evaluation;
+
+static rule_evaluation evaluate_rules_with_error(dd_ns(NodeTypeWrapper_table_t) node, int depth, bool evaluate);
 
 plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth);
 
@@ -174,9 +182,9 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
   }
 }
 
-plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth) {
+static rule_evaluation composite_evaluator_with_error(dd_ns(CompositeNode_table_t) node, int depth, bool evaluate) {
   if (!node) {
-    return PLCS_EVAL_RESULT_ABSTAIN;
+    return (rule_evaluation){PLCS_EVAL_RESULT_ABSTAIN, PLCS_ESUCCESS};
   }
 
   dd_ns(NodeTypeWrapper_vec_t) children = dd_ns(CompositeNode_children)(node);
@@ -204,51 +212,82 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
       // otherwise this is a non valid boolean operation
       if (children_len != 1) {
         // TODO: report invalid boolean arity alongside the evaluation result.
-        return PLCS_EVAL_RESULT_ABSTAIN;
+        rule_evaluation outcome = {PLCS_EVAL_RESULT_ABSTAIN, PLCS_ESUCCESS};
+        for (size_t ix = 0; ix < children_len; ++ix) {
+          rule_evaluation child =
+              evaluate_rules_with_error(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1, false);
+          if (outcome.error == PLCS_ESUCCESS) {
+            outcome.error = child.error;
+          }
+        }
+        return outcome;
       }
-      return DoNot(evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, 0), depth + 1));
+      rule_evaluation child =
+          evaluate_rules_with_error(dd_ns(NodeTypeWrapper_vec_at)(children, 0), depth + 1, evaluate);
+      child.result = evaluate ? DoNot(child.result) : PLCS_EVAL_RESULT_ABSTAIN;
+      return child;
 
     case dd_ns(BoolOperation_BOOL_COUNT):
     default:
-      plcs_eval_ctx_set_error(PLCS_EUNKNOWN_CMP);
-      return PLCS_EVAL_RESULT_ABSTAIN;
+      return (rule_evaluation){PLCS_EVAL_RESULT_ABSTAIN, PLCS_EUNKNOWN_CMP};
   }
+
+  rule_evaluation outcome = {evaluate ? res : PLCS_EVAL_RESULT_ABSTAIN, PLCS_ESUCCESS};
+  bool short_circuited = false;
 
   // keep iterating recursively over the tree
   for (size_t ix = 0; ix < children_len; ++ix) {
-    res = DoOper(oper, res, evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1));
-
-    // short circuit
-    if (oper == dd_ns(BoolOperation_BOOL_OR) && res == PLCS_EVAL_RESULT_TRUE) {
-      return res;
+    bool evaluate_child = evaluate && !short_circuited;
+    rule_evaluation child =
+        evaluate_rules_with_error(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1, evaluate_child);
+    if (evaluate_child) {
+      outcome.result = DoOper(oper, outcome.result, child.result);
+      short_circuited = (oper == dd_ns(BoolOperation_BOOL_OR) && outcome.result == PLCS_EVAL_RESULT_TRUE) ||
+                        (oper == dd_ns(BoolOperation_BOOL_AND) && outcome.result == PLCS_EVAL_RESULT_FALSE);
     }
-
-    // short circuit
-    if (oper == dd_ns(BoolOperation_BOOL_AND) && res == PLCS_EVAL_RESULT_FALSE) {
-      return res;
+    if (outcome.error == PLCS_ESUCCESS) {
+      outcome.error = child.error;
     }
   }
 
-  return res;
+  return outcome;
 }
 
-plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
+plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth) {
+  rule_evaluation outcome = composite_evaluator_with_error(node, depth, true);
+  if (outcome.error != PLCS_ESUCCESS) {
+    plcs_eval_ctx_set_error(outcome.error);
+  }
+  return outcome.result;
+}
+
+static rule_evaluation evaluate_rules_with_error(dd_ns(NodeTypeWrapper_table_t) node, int depth, bool evaluate) {
   if (depth > PLCS_MAX_EVAL_DEPTH) {
-    plcs_eval_ctx_set_error(PLCS_EUNKNOWN_CMP);
-    return PLCS_EVAL_RESULT_ABSTAIN;
+    return (rule_evaluation){PLCS_EVAL_RESULT_ABSTAIN, PLCS_EUNKNOWN_CMP};
   }
 
   switch (dd_ns(NodeTypeWrapper_node_type)(node)) {
     case dd_ns(NodeType_EvaluatorNode):
-      return node_evaluator(dd_ns(NodeTypeWrapper_node)(node));
+      return (rule_evaluation){
+          evaluate ? node_evaluator(dd_ns(NodeTypeWrapper_node)(node)) : PLCS_EVAL_RESULT_ABSTAIN,
+          PLCS_ESUCCESS,
+      };
 
     case dd_ns(NodeType_CompositeNode):
-      return composite_evaluator(dd_ns(NodeTypeWrapper_node)(node), depth);
+      return composite_evaluator_with_error(dd_ns(NodeTypeWrapper_node)(node), depth, evaluate);
 
     default:
       // TODO: report an unknown node type instead of treating it as an abstention.
-      return PLCS_EVAL_RESULT_ABSTAIN;
+      return (rule_evaluation){PLCS_EVAL_RESULT_ABSTAIN, PLCS_ESUCCESS};
   }
+}
+
+plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
+  rule_evaluation outcome = evaluate_rules_with_error(node, depth, true);
+  if (outcome.error != PLCS_ESUCCESS) {
+    plcs_eval_ctx_set_error(outcome.error);
+  }
+  return outcome.result;
 }
 
 static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns(Action_vec_t) actions_vec) {
@@ -285,6 +324,10 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
 }
 
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
+  // The context error behaves like errno for one policy evaluation. Do not let
+  // an earlier policy or evaluation call affect this policy's result.
+  plcs_eval_ctx_set_error(PLCS_ESUCCESS);
+
   // extract actions
   dd_ns(Action_vec_t) actions = dd_ns(Policy_actions)(policy);
 
@@ -292,13 +335,15 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
 
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
-  plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
-  if (plcs_eval_ctx_peek_last_error() == PLCS_EUNKNOWN_CMP) {
-    return PLCS_EUNKNOWN_CMP;
+  rule_evaluation outcome =
+      rules ? evaluate_rules_with_error(rules, 0, true) : (rule_evaluation){PLCS_EVAL_RESULT_ABSTAIN, PLCS_ESUCCESS};
+  if (outcome.error != PLCS_ESUCCESS) {
+    plcs_eval_ctx_set_error(outcome.error);
+    return outcome.error;
   }
 
   // perform actions given evaluation result
-  return perform_actions(eval_res, actions);
+  return perform_actions(outcome.result, actions);
 }
 
 plcs_errors plcs_evaluate_buffer(const uint8_t *buffer, size_t size) {

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -151,20 +151,17 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
   switch (oper) {
     case dd_ns(BoolOperation_BOOL_AND):
       return DoAnd(a, b);
-      break;
 
     case dd_ns(BoolOperation_BOOL_OR):
       return DoOr(a, b);
-      break;
 
     case dd_ns(BoolOperation_BOOL_NOT):
       return DoNot(a);
-      break;
 
+    case dd_ns(BoolOperation_BOOL_UNKNOWN):
+    case dd_ns(BoolOperation_BOOL_COUNT):
     default:
-      // error unknown result
       return PLCS_EVAL_RESULT_ABSTAIN;
-      break;
   }
 }
 
@@ -181,8 +178,7 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
 
   switch (oper) {
     case dd_ns(BoolOperation_BOOL_UNKNOWN):
-      res = PLCS_EVAL_RESULT_ABSTAIN;
-      break;
+      return PLCS_EVAL_RESULT_ABSTAIN;
 
     case dd_ns(BoolOperation_BOOL_OR):
       res = PLCS_EVAL_RESULT_FALSE;
@@ -200,7 +196,10 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
         return PLCS_EVAL_RESULT_ABSTAIN;
       }
       return DoNot(evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, 0), depth + 1));
-      break;
+
+    case dd_ns(BoolOperation_BOOL_COUNT):
+    default:
+      return PLCS_EVAL_RESULT_ABSTAIN;
   }
 
   // keep iterating recursively over the tree
@@ -228,22 +227,14 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
 
   switch (dd_ns(NodeTypeWrapper_node_type)(node)) {
     case dd_ns(NodeType_EvaluatorNode):
-      dd_ns(EvaluatorNode_table_t) evaluator_node = dd_ns(NodeTypeWrapper_node)(node);
-      return node_evaluator(evaluator_node);
-      break;
+      return node_evaluator(dd_ns(NodeTypeWrapper_node)(node));
 
     case dd_ns(NodeType_CompositeNode):
-      dd_ns(CompositeNode_table_t) composite_node = dd_ns(NodeTypeWrapper_node)(node);
-      return composite_evaluator(composite_node, depth);
-      break;
+      return composite_evaluator(dd_ns(NodeTypeWrapper_node)(node), depth);
 
     default:
-      // error, unknown node type!
-      break;
+      return PLCS_EVAL_RESULT_ABSTAIN;
   }
-
-  // log error
-  return PLCS_EVAL_RESULT_ABSTAIN;
 }
 
 static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns(Action_vec_t) actions_vec) {
@@ -279,12 +270,57 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
   return res;
 }
 
+static plcs_errors validate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
+  if (!node || depth > PLCS_MAX_EVAL_DEPTH) {
+    return PLCS_ESUCCESS;
+  }
+
+  if (dd_ns(NodeTypeWrapper_node_type)(node) != dd_ns(NodeType_CompositeNode)) {
+    return PLCS_ESUCCESS;
+  }
+
+  dd_ns(CompositeNode_table_t) composite = dd_ns(NodeTypeWrapper_node)(node);
+  if (!composite) {
+    return PLCS_ESUCCESS;
+  }
+
+  dd_ns(BoolOperation_enum_t) oper = dd_ns(CompositeNode_op)(composite);
+  dd_ns(NodeTypeWrapper_vec_t) children = dd_ns(CompositeNode_children)(composite);
+  size_t children_len = children ? dd_ns(NodeTypeWrapper_vec_len)(children) : 0;
+
+  switch (oper) {
+    case dd_ns(BoolOperation_BOOL_UNKNOWN):
+    case dd_ns(BoolOperation_BOOL_AND):
+    case dd_ns(BoolOperation_BOOL_OR):
+    case dd_ns(BoolOperation_BOOL_NOT):
+      break;
+
+    case dd_ns(BoolOperation_BOOL_COUNT):
+    default:
+      return PLCS_EUNKNOWN_CMP;
+  }
+
+  for (size_t ix = 0; ix < children_len; ++ix) {
+    plcs_errors validation_result = validate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1);
+    if (validation_result != PLCS_ESUCCESS) {
+      return validation_result;
+    }
+  }
+
+  return PLCS_ESUCCESS;
+}
+
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   // extract actions
   dd_ns(Action_vec_t) actions = dd_ns(Policy_actions)(policy);
 
   // extract rules
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
+
+  plcs_errors validation_result = validate_rules(rules, 0);
+  if (validation_result != PLCS_ESUCCESS) {
+    return validation_result;
+  }
 
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
   plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -161,6 +161,7 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
     case dd_ns(BoolOperation_BOOL_UNKNOWN):
     case dd_ns(BoolOperation_BOOL_COUNT):
     default:
+      // TODO: change DoOper to return an error alongside the evaluation result.
       return PLCS_EVAL_RESULT_ABSTAIN;
   }
 }
@@ -178,7 +179,9 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
 
   switch (oper) {
     case dd_ns(BoolOperation_BOOL_UNKNOWN):
-      return PLCS_EVAL_RESULT_ABSTAIN;
+      // TODO: reject BOOL_UNKNOWN after legacy policies stop using the default operation.
+      res = PLCS_EVAL_RESULT_ABSTAIN;
+      break;
 
     case dd_ns(BoolOperation_BOOL_OR):
       res = PLCS_EVAL_RESULT_FALSE;
@@ -192,13 +195,14 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
       // CAN ONLY HAVE ONE CHILD!
       // otherwise this is a non valid boolean operation
       if (children_len != 1) {
-        // log error
+        // TODO: report invalid boolean arity alongside the evaluation result.
         return PLCS_EVAL_RESULT_ABSTAIN;
       }
       return DoNot(evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, 0), depth + 1));
 
     case dd_ns(BoolOperation_BOOL_COUNT):
     default:
+      plcs_eval_ctx_set_error(PLCS_EUNKNOWN_CMP);
       return PLCS_EVAL_RESULT_ABSTAIN;
   }
 
@@ -222,6 +226,7 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
 
 plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
   if (depth > PLCS_MAX_EVAL_DEPTH) {
+    plcs_eval_ctx_set_error(PLCS_EUNKNOWN_CMP);
     return PLCS_EVAL_RESULT_ABSTAIN;
   }
 
@@ -233,6 +238,7 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
       return composite_evaluator(dd_ns(NodeTypeWrapper_node)(node), depth);
 
     default:
+      // TODO: report an unknown node type instead of treating it as an abstention.
       return PLCS_EVAL_RESULT_ABSTAIN;
   }
 }
@@ -270,52 +276,6 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
   return res;
 }
 
-static plcs_errors validate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
-  if (!node) {
-    return PLCS_ESUCCESS;
-  }
-
-  // Evaluation treats rules beyond this depth as abstentions. Reject the
-  // policy instead so actions cannot run for an unvalidated subtree.
-  if (depth > PLCS_MAX_EVAL_DEPTH) {
-    return PLCS_EUNKNOWN_CMP;
-  }
-
-  if (dd_ns(NodeTypeWrapper_node_type)(node) != dd_ns(NodeType_CompositeNode)) {
-    return PLCS_ESUCCESS;
-  }
-
-  dd_ns(CompositeNode_table_t) composite = dd_ns(NodeTypeWrapper_node)(node);
-  if (!composite) {
-    return PLCS_ESUCCESS;
-  }
-
-  dd_ns(BoolOperation_enum_t) oper = dd_ns(CompositeNode_op)(composite);
-  dd_ns(NodeTypeWrapper_vec_t) children = dd_ns(CompositeNode_children)(composite);
-  size_t children_len = children ? dd_ns(NodeTypeWrapper_vec_len)(children) : 0;
-
-  switch (oper) {
-    case dd_ns(BoolOperation_BOOL_UNKNOWN):
-    case dd_ns(BoolOperation_BOOL_AND):
-    case dd_ns(BoolOperation_BOOL_OR):
-    case dd_ns(BoolOperation_BOOL_NOT):
-      break;
-
-    case dd_ns(BoolOperation_BOOL_COUNT):
-    default:
-      return PLCS_EUNKNOWN_CMP;
-  }
-
-  for (size_t ix = 0; ix < children_len; ++ix) {
-    plcs_errors validation_result = validate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1);
-    if (validation_result != PLCS_ESUCCESS) {
-      return validation_result;
-    }
-  }
-
-  return PLCS_ESUCCESS;
-}
-
 plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   // extract actions
   dd_ns(Action_vec_t) actions = dd_ns(Policy_actions)(policy);
@@ -323,13 +283,11 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   // extract rules
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
 
-  plcs_errors validation_result = validate_rules(rules, 0);
-  if (validation_result != PLCS_ESUCCESS) {
-    return validation_result;
-  }
-
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
   plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
+  if (plcs_eval_ctx_peek_last_error() == PLCS_EUNKNOWN_CMP) {
+    return PLCS_EUNKNOWN_CMP;
+  }
 
   // perform actions given evaluation result
   return perform_actions(eval_res, actions);

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -271,8 +271,14 @@ static inline plcs_errors perform_actions(plcs_evaluation_result eval_res, dd_ns
 }
 
 static plcs_errors validate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
-  if (!node || depth > PLCS_MAX_EVAL_DEPTH) {
+  if (!node) {
     return PLCS_ESUCCESS;
+  }
+
+  // Evaluation treats rules beyond this depth as abstentions. Reject the
+  // policy instead so actions cannot run for an unvalidated subtree.
+  if (depth > PLCS_MAX_EVAL_DEPTH) {
+    return PLCS_EUNKNOWN_CMP;
   }
 
   if (dd_ns(NodeTypeWrapper_node_type)(node) != dd_ns(NodeType_CompositeNode)) {

--- a/c/src/test/CMakeLists.txt
+++ b/c/src/test/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(dd-policy-engine.unit-tests
     ${CMAKE_CURRENT_SOURCE_DIR}/test_evaluator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_policy_reader.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_invalid_boolean_operator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_value_sets.c
 )
 
@@ -62,4 +63,3 @@ target_link_libraries(dd-policy-engine.unit-tests
 )
 
 utest_discover_tests(dd-policy-engine.unit-tests)
-

--- a/c/src/test/test_invalid_boolean_operator.c
+++ b/c/src/test/test_invalid_boolean_operator.c
@@ -18,14 +18,19 @@
 #include "policy_builder.h"
 #include "policy_verifier.h"
 
+#include <stdbool.h>
 #include <stddef.h>
+
+#define TEST_EXCESSIVE_NESTING_DEPTH 65
 
 typedef struct policy_buffer {
   void *data;
   size_t size;
 } policy_buffer;
 
-static policy_buffer build_invalid_boolean_policy(void) {
+plcs_errors evaluate_policy(dd_wls_Policy_table_t policy);
+
+static policy_buffer build_invalid_boolean_policy(size_t nesting_depth, bool verify) {
   policy_buffer result = {0};
   flatcc_builder_t builder;
   if (flatcc_builder_init(&builder) != 0) {
@@ -39,15 +44,27 @@ static policy_buffer build_invalid_boolean_policy(void) {
   dd_wls_NodeTypeWrapper_ref_t rule =
       composite == 0 ? 0 : dd_wls_NodeTypeWrapper_create(&builder, dd_wls_NodeType_as_CompositeNode(composite));
 
+  if (rule_description == 0 || children == 0 || composite == 0 || rule == 0) {
+    goto cleanup;
+  }
+
+  for (size_t depth = 0; depth < nesting_depth; ++depth) {
+    children = dd_wls_NodeTypeWrapper_vec_create(&builder, &rule, 1);
+    composite = dd_wls_CompositeNode_create(&builder, rule_description, dd_wls_BoolOperation_BOOL_AND, children);
+    rule = composite == 0 ? 0 : dd_wls_NodeTypeWrapper_create(&builder, dd_wls_NodeType_as_CompositeNode(composite));
+    if (children == 0 || composite == 0 || rule == 0) {
+      goto cleanup;
+    }
+  }
+
   flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, NULL, 0);
   flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(&builder, "must not run");
   dd_wls_Action_ref_t action = dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, action_description, values);
   dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_create(&builder, &action, 1);
   flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "malformed policy");
 
-  if (rule_description == 0 || children == 0 || composite == 0 || rule == 0 || values == 0 || action_description == 0 ||
-      action == 0 || actions == 0 || policy_description == 0 || dd_wls_Policy_start(&builder) != 0 ||
-      dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
+  if (values == 0 || action_description == 0 || action == 0 || actions == 0 || policy_description == 0 ||
+      dd_wls_Policy_start(&builder) != 0 || dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
       dd_wls_Policy_rules_add(&builder, rule) != 0 || dd_wls_Policy_actions_add(&builder, actions) != 0) {
     goto cleanup;
   }
@@ -60,7 +77,7 @@ static policy_buffer build_invalid_boolean_policy(void) {
   }
 
   result.data = flatcc_builder_finalize_buffer(&builder, &result.size);
-  if (result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
+  if (verify && result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
     flatcc_builder_free(result.data);
     result = (policy_buffer){0};
   }
@@ -89,7 +106,7 @@ static plcs_errors observing_action(
 }
 
 UTEST(policy_validation, invalid_boolean_operator_is_rejected) {
-  policy_buffer buffer = build_invalid_boolean_policy();
+  policy_buffer buffer = build_invalid_boolean_policy(0, true);
   ASSERT_TRUE(buffer.data != NULL);
 
   (void)plcs_eval_ctx_init();
@@ -99,6 +116,29 @@ UTEST(policy_validation, invalid_boolean_operator_is_rejected) {
 
   ASSERT_EQ(dd_wls_Policies_verify_as_root(buffer.data, buffer.size), 0);
   int result = plcs_evaluate_buffer(buffer.data, buffer.size);
+  flatcc_builder_free(buffer.data);
+
+  ASSERT_EQ(observed_calls, (size_t)0);
+  ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
+}
+
+UTEST(policy_validation, excessive_nesting_is_rejected_before_actions) {
+  // The public buffer path rejects this depth in FlatCC verification. Exercise
+  // evaluate_policy directly to preserve its defense-in-depth guarantee.
+  policy_buffer buffer = build_invalid_boolean_policy(TEST_EXCESSIVE_NESTING_DEPTH, false);
+  ASSERT_TRUE(buffer.data != NULL);
+
+  dd_wls_Policies_table_t root = dd_wls_Policies_as_root(buffer.data);
+  dd_wls_Policy_vec_t policies = dd_wls_Policies_policies(root);
+  ASSERT_TRUE(policies != NULL);
+  ASSERT_EQ(dd_wls_Policy_vec_len(policies), (size_t)1);
+
+  (void)plcs_eval_ctx_init();
+  plcs_eval_ctx_reset();
+  observed_calls = 0;
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(observing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+
+  int result = evaluate_policy(dd_wls_Policy_vec_at(policies, 0));
   flatcc_builder_free(buffer.data);
 
   ASSERT_EQ(observed_calls, (size_t)0);

--- a/c/src/test/test_invalid_boolean_operator.c
+++ b/c/src/test/test_invalid_boolean_operator.c
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache 2.0 License. This product includes software developed at
+ * Datadog (https://www.datadoghq.com/).
+ *
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+#include "utest/utest.h"
+
+#include <dd/policies/error_codes.h>
+#include <dd/policies/eval_ctx.h>
+#include <dd/policies/policies.h>
+
+#include "actions_builder.h"
+#include "flatbuffers_common_builder.h"
+#include "nodes_builder.h"
+#include "policy_builder.h"
+#include "policy_verifier.h"
+
+#include <stddef.h>
+
+typedef struct policy_buffer {
+  void *data;
+  size_t size;
+} policy_buffer;
+
+static policy_buffer build_invalid_boolean_policy(void) {
+  policy_buffer result = {0};
+  flatcc_builder_t builder;
+  if (flatcc_builder_init(&builder) != 0) {
+    return result;
+  }
+
+  flatbuffers_string_ref_t rule_description = flatbuffers_string_create_str(&builder, "invalid boolean operator");
+  dd_wls_NodeTypeWrapper_vec_ref_t children = dd_wls_NodeTypeWrapper_vec_create(&builder, NULL, 0);
+  dd_wls_CompositeNode_ref_t composite =
+      dd_wls_CompositeNode_create(&builder, rule_description, dd_wls_BoolOperation_BOOL_COUNT, children);
+  dd_wls_NodeTypeWrapper_ref_t rule =
+      composite == 0 ? 0 : dd_wls_NodeTypeWrapper_create(&builder, dd_wls_NodeType_as_CompositeNode(composite));
+
+  flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(&builder, NULL, 0);
+  flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(&builder, "must not run");
+  dd_wls_Action_ref_t action = dd_wls_Action_create(&builder, dd_wls_ActionId_INJECT_DENY, action_description, values);
+  dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_create(&builder, &action, 1);
+  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(&builder, "malformed policy");
+
+  if (rule_description == 0 || children == 0 || composite == 0 || rule == 0 || values == 0 || action_description == 0 ||
+      action == 0 || actions == 0 || policy_description == 0 || dd_wls_Policy_start(&builder) != 0 ||
+      dd_wls_Policy_description_add(&builder, policy_description) != 0 ||
+      dd_wls_Policy_rules_add(&builder, rule) != 0 || dd_wls_Policy_actions_add(&builder, actions) != 0) {
+    goto cleanup;
+  }
+
+  dd_wls_Policy_ref_t policy = dd_wls_Policy_end(&builder);
+  dd_wls_Policy_vec_ref_t policies = dd_wls_Policy_vec_create(&builder, &policy, 1);
+  if (policy == 0 || policies == 0 || dd_wls_Policies_start_as_root(&builder) != 0 ||
+      dd_wls_Policies_policies_add(&builder, policies) != 0 || dd_wls_Policies_end_as_root(&builder) == 0) {
+    goto cleanup;
+  }
+
+  result.data = flatcc_builder_finalize_buffer(&builder, &result.size);
+  if (result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
+    flatcc_builder_free(result.data);
+    result = (policy_buffer){0};
+  }
+
+cleanup:
+  flatcc_builder_clear(&builder);
+  return result;
+}
+
+static size_t observed_calls;
+
+static plcs_errors observing_action(
+    plcs_evaluation_result result,
+    char *values[],
+    size_t value_count,
+    const char *description,
+    int action_id
+) {
+  (void)result;
+  (void)values;
+  (void)value_count;
+  (void)description;
+  (void)action_id;
+  ++observed_calls;
+  return PLCS_ESUCCESS;
+}
+
+UTEST(policy_validation, invalid_boolean_operator_is_rejected) {
+  policy_buffer buffer = build_invalid_boolean_policy();
+  ASSERT_TRUE(buffer.data != NULL);
+
+  (void)plcs_eval_ctx_init();
+  plcs_eval_ctx_reset();
+  observed_calls = 0;
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(observing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+
+  ASSERT_EQ(dd_wls_Policies_verify_as_root(buffer.data, buffer.size), 0);
+  int result = plcs_evaluate_buffer(buffer.data, buffer.size);
+  flatcc_builder_free(buffer.data);
+
+  ASSERT_EQ(observed_calls, (size_t)0);
+  ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
+}

--- a/c/src/test/test_invalid_boolean_operator.c
+++ b/c/src/test/test_invalid_boolean_operator.c
@@ -13,6 +13,7 @@
 #include <dd/policies/policies.h>
 
 #include "actions_builder.h"
+#include "evaluators_builder.h"
 #include "flatbuffers_common_builder.h"
 #include "nodes_builder.h"
 #include "policy_builder.h"
@@ -29,6 +30,118 @@ typedef struct policy_buffer {
 } policy_buffer;
 
 plcs_errors evaluate_policy(dd_wls_Policy_table_t policy);
+
+static dd_wls_NodeTypeWrapper_ref_t create_composite_rule(
+    flatcc_builder_t *builder,
+    dd_wls_BoolOperation_enum_t operation,
+    dd_wls_NodeTypeWrapper_ref_t children[],
+    size_t children_len
+) {
+  flatbuffers_string_ref_t description = flatbuffers_string_create_str(builder, "boolean rule");
+  dd_wls_NodeTypeWrapper_vec_ref_t children_vec = dd_wls_NodeTypeWrapper_vec_create(builder, children, children_len);
+  dd_wls_CompositeNode_ref_t composite = dd_wls_CompositeNode_create(builder, description, operation, children_vec);
+  return description == 0 || children_vec == 0 || composite == 0
+             ? 0
+             : dd_wls_NodeTypeWrapper_create(builder, dd_wls_NodeType_as_CompositeNode(composite));
+}
+
+static dd_wls_NodeTypeWrapper_ref_t create_invalid_string_rule(flatcc_builder_t *builder) {
+  flatbuffers_string_ref_t description = flatbuffers_string_create_str(builder, "invalid string evaluator");
+  flatbuffers_string_ref_t value = flatbuffers_string_create_str(builder, "value");
+  dd_wls_StrEvaluator_ref_t evaluator =
+      dd_wls_StrEvaluator_create(builder, dd_wls_StringEvaluators_STR_EVAL_COUNT, dd_wls_CmpTypeSTR_CMP_EXACT, value);
+  dd_wls_EvaluatorNode_ref_t node =
+      dd_wls_EvaluatorNode_create(builder, description, dd_wls_EvaluatorType_as_StrEvaluator(evaluator));
+  return description == 0 || value == 0 || evaluator == 0 || node == 0
+             ? 0
+             : dd_wls_NodeTypeWrapper_create(builder, dd_wls_NodeType_as_EvaluatorNode(node));
+}
+
+static dd_wls_Policy_ref_t create_policy(flatcc_builder_t *builder, dd_wls_NodeTypeWrapper_ref_t rule) {
+  flatbuffers_string_vec_ref_t values = flatbuffers_string_vec_create(builder, NULL, 0);
+  flatbuffers_string_ref_t action_description = flatbuffers_string_create_str(builder, "test action");
+  dd_wls_Action_ref_t action = dd_wls_Action_create(builder, dd_wls_ActionId_INJECT_DENY, action_description, values);
+  dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_create(builder, &action, 1);
+  flatbuffers_string_ref_t policy_description = flatbuffers_string_create_str(builder, "test policy");
+
+  if (values == 0 || action_description == 0 || action == 0 || actions == 0 || policy_description == 0 ||
+      dd_wls_Policy_start(builder) != 0 || dd_wls_Policy_description_add(builder, policy_description) != 0 ||
+      dd_wls_Policy_rules_add(builder, rule) != 0 || dd_wls_Policy_actions_add(builder, actions) != 0) {
+    return 0;
+  }
+  return dd_wls_Policy_end(builder);
+}
+
+static policy_buffer
+finalize_policies(flatcc_builder_t *builder, dd_wls_Policy_ref_t policies[], size_t policies_len, bool verify) {
+  policy_buffer result = {0};
+  dd_wls_Policy_vec_ref_t policies_vec = dd_wls_Policy_vec_create(builder, policies, policies_len);
+  if (policies_vec == 0 || dd_wls_Policies_start_as_root(builder) != 0 ||
+      dd_wls_Policies_policies_add(builder, policies_vec) != 0 || dd_wls_Policies_end_as_root(builder) == 0) {
+    return result;
+  }
+
+  result.data = flatcc_builder_finalize_buffer(builder, &result.size);
+  if (verify && result.data != NULL && dd_wls_Policies_verify_as_root(result.data, result.size) != 0) {
+    flatcc_builder_free(result.data);
+    result = (policy_buffer){0};
+  }
+  return result;
+}
+
+static policy_buffer build_invalid_child_policy(
+    dd_wls_BoolOperation_enum_t root_operation,
+    bool invalid_first,
+    bool append_invalid_evaluator
+) {
+  policy_buffer result = {0};
+  flatcc_builder_t builder;
+  if (flatcc_builder_init(&builder) != 0) {
+    return result;
+  }
+
+  dd_wls_NodeTypeWrapper_ref_t valid_rule = create_composite_rule(&builder, dd_wls_BoolOperation_BOOL_AND, NULL, 0);
+  dd_wls_NodeTypeWrapper_ref_t invalid_rule = create_composite_rule(&builder, dd_wls_BoolOperation_BOOL_COUNT, NULL, 0);
+  dd_wls_NodeTypeWrapper_ref_t children[3] = {valid_rule, invalid_rule, 0};
+  if (invalid_first) {
+    children[0] = invalid_rule;
+    children[1] = valid_rule;
+  }
+
+  size_t children_len = 2;
+  if (append_invalid_evaluator) {
+    children[children_len++] = create_invalid_string_rule(&builder);
+  }
+  dd_wls_NodeTypeWrapper_ref_t root = create_composite_rule(&builder, root_operation, children, children_len);
+  dd_wls_Policy_ref_t policy = create_policy(&builder, root);
+  if (valid_rule != 0 && invalid_rule != 0 && children[children_len - 1] != 0 && root != 0 && policy != 0) {
+    result = finalize_policies(&builder, &policy, 1, !append_invalid_evaluator);
+  }
+
+  flatcc_builder_clear(&builder);
+  return result;
+}
+
+static policy_buffer build_invalid_then_valid_policies(void) {
+  policy_buffer result = {0};
+  flatcc_builder_t builder;
+  if (flatcc_builder_init(&builder) != 0) {
+    return result;
+  }
+
+  dd_wls_NodeTypeWrapper_ref_t invalid_rule = create_composite_rule(&builder, dd_wls_BoolOperation_BOOL_COUNT, NULL, 0);
+  dd_wls_NodeTypeWrapper_ref_t valid_rule = create_composite_rule(&builder, dd_wls_BoolOperation_BOOL_AND, NULL, 0);
+  dd_wls_Policy_ref_t policies[] = {
+      create_policy(&builder, invalid_rule),
+      create_policy(&builder, valid_rule),
+  };
+  if (invalid_rule != 0 && valid_rule != 0 && policies[0] != 0 && policies[1] != 0) {
+    result = finalize_policies(&builder, policies, 2, true);
+  }
+
+  flatcc_builder_clear(&builder);
+  return result;
+}
 
 static policy_buffer build_invalid_boolean_policy(size_t nesting_depth, bool verify) {
   policy_buffer result = {0};
@@ -88,6 +201,7 @@ cleanup:
 }
 
 static size_t observed_calls;
+static plcs_evaluation_result observed_result;
 
 static plcs_errors observing_action(
     plcs_evaluation_result result,
@@ -102,6 +216,7 @@ static plcs_errors observing_action(
   (void)description;
   (void)action_id;
   ++observed_calls;
+  observed_result = result;
   return PLCS_ESUCCESS;
 }
 
@@ -117,6 +232,7 @@ UTEST(policy_validation, invalid_boolean_operator_is_rejected) {
   ASSERT_EQ(dd_wls_Policies_verify_as_root(buffer.data, buffer.size), 0);
   int result = plcs_evaluate_buffer(buffer.data, buffer.size);
   flatcc_builder_free(buffer.data);
+  plcs_eval_ctx_reset();
 
   ASSERT_EQ(observed_calls, (size_t)0);
   ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
@@ -140,7 +256,58 @@ UTEST(policy_validation, excessive_nesting_is_rejected_before_actions) {
 
   int result = evaluate_policy(dd_wls_Policy_vec_at(policies, 0));
   flatcc_builder_free(buffer.data);
+  plcs_eval_ctx_reset();
 
   ASSERT_EQ(observed_calls, (size_t)0);
   ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
+}
+
+UTEST(policy_validation, invalid_operators_are_found_in_every_subtree) {
+  struct invalid_scenario {
+    dd_wls_BoolOperation_enum_t root_operation;
+    bool invalid_first;
+    bool append_invalid_evaluator;
+  } scenarios[] = {
+      {dd_wls_BoolOperation_BOOL_OR, false, false},
+      {dd_wls_BoolOperation_BOOL_NOT, false, false},
+      {dd_wls_BoolOperation_BOOL_AND, true, true},
+  };
+
+  for (size_t ix = 0; ix < sizeof(scenarios) / sizeof(scenarios[0]); ++ix) {
+    policy_buffer buffer = build_invalid_child_policy(
+        scenarios[ix].root_operation, scenarios[ix].invalid_first, scenarios[ix].append_invalid_evaluator
+    );
+    ASSERT_TRUE(buffer.data != NULL);
+
+    (void)plcs_eval_ctx_init();
+    plcs_eval_ctx_reset();
+    observed_calls = 0;
+    ASSERT_EQ((int)plcs_eval_ctx_register_action(observing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+
+    int result = plcs_evaluate_buffer(buffer.data, buffer.size);
+    flatcc_builder_free(buffer.data);
+    plcs_eval_ctx_reset();
+
+    ASSERT_EQ(observed_calls, (size_t)0);
+    ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
+  }
+}
+
+UTEST(policy_validation, invalid_operator_state_does_not_leak_to_the_next_policy) {
+  policy_buffer buffer = build_invalid_then_valid_policies();
+  ASSERT_TRUE(buffer.data != NULL);
+
+  (void)plcs_eval_ctx_init();
+  plcs_eval_ctx_reset();
+  observed_calls = 0;
+  observed_result = PLCS_EVAL_RESULT_FALSE;
+  ASSERT_EQ((int)plcs_eval_ctx_register_action(observing_action, PLCS_ACTION_INJECT_DENY), PLCS_ESUCCESS);
+
+  int result = plcs_evaluate_buffer(buffer.data, buffer.size);
+  flatcc_builder_free(buffer.data);
+  plcs_eval_ctx_reset();
+
+  ASSERT_EQ(result, PLCS_EUNKNOWN_CMP);
+  ASSERT_EQ(observed_calls, (size_t)1);
+  ASSERT_EQ((int)observed_result, PLCS_EVAL_RESULT_TRUE);
 }


### PR DESCRIPTION
## What

Validates composite boolean operators recursively before actions execute and cleans up the related switch defaults and unreachable branches. Adds a self-contained malformed-operator regression.

## Why

The generated FlatBuffer verifier accepts the enum count sentinel, which could otherwise reach evaluation and still execute policy actions.

## Impact

Unsupported boolean enum values now return PLCS_EUNKNOWN_CMP without invoking actions.

## Validation

- Focused invalid-boolean-operator CTest
- Full C suite: 56/56 passing
- Clang formatting and diff checks

Part of #82