### PR TITLE
[codex] Normalize deny operating systems

### DIFF
--- a/go/cmd/dd-requirements-converter/converter/deny.go
+++ b/go/cmd/dd-requirements-converter/converter/deny.go
@@ -19,8 +19,15 @@ type JSONDeny struct {
 	Envs        map[string]*string `json:"envars"`
 }
 
-func isValidOS(os string) bool {
-	return os == "windows" || os == "linux" || os == "darwin"
+func normalizeOS(os string) (string, bool) {
+	switch os {
+	case "windows", "linux":
+		return os, true
+	case "darwin", "macos":
+		return "macos", true
+	default:
+		return "", false
+	}
 }
 
 func (d JSONDeny) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffers.UOffsetT, error) {
@@ -30,8 +37,13 @@ func (d JSONDeny) ConvertToWLS(builder *flatbuffers.Builder) (flatbuffers.UOffse
 		return 0, errors.New("no conditions to match")
 	}
 
-	if d.Os != "" && isValidOS(d.Os) {
-		osEval := schema.StrEvaluatorCreate(builder, wls.StringEvaluatorsOS, d.Os, wls.CmpTypeSTRCMP_EXACT)
+	if d.Os != "" {
+		os, ok := normalizeOS(d.Os)
+		if !ok {
+			return 0, errors.New("unknown operating system")
+		}
+
+		osEval := schema.StrEvaluatorCreate(builder, wls.StringEvaluatorsOS, os, wls.CmpTypeSTRCMP_EXACT)
 		osNode := schema.EvaluatorNodeCreate(builder, wls.EvaluatorTypeStrEvaluator, "OS matching", osEval)
 		nodes = append(nodes, schema.NodeTypeWrapperCreate(builder, osNode, wls.NodeTypeEvaluatorNode))
 	}

--- a/go/cmd/dd-requirements-converter/converter/deny_os_normalization_test.go
+++ b/go/cmd/dd-requirements-converter/converter/deny_os_normalization_test.go
@@ -1,0 +1,63 @@
+package converter
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-policy-engine/go/schema/dd/wls"
+
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+
+func convertedOSValue(t *testing.T, input string) string {
+	t.Helper()
+
+	builder := flatbuffers.NewBuilder(128)
+	offset, err := (JSONDeny{Os: input}).ConvertToWLS(builder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder.Finish(offset)
+
+	root := wls.GetRootAsNodeTypeWrapper(builder.FinishedBytes(), 0)
+	if root.NodeType() != wls.NodeTypeEvaluatorNode {
+		t.Fatalf("unexpected root node type %s", root.NodeType())
+	}
+
+	var table flatbuffers.Table
+	if !root.Node(&table) {
+		t.Fatal("root node has no value")
+	}
+	var node wls.EvaluatorNode
+	node.Init(table.Bytes, table.Pos)
+	if node.EvalType() != wls.EvaluatorTypeStrEvaluator || !node.Eval(&table) {
+		t.Fatalf("unexpected evaluator type %s", node.EvalType())
+	}
+
+	var evaluator wls.StrEvaluator
+	evaluator.Init(table.Bytes, table.Pos)
+	if evaluator.Id() != wls.StringEvaluatorsOS {
+		t.Fatalf("unexpected string evaluator %s", evaluator.Id())
+	}
+	return string(evaluator.Value())
+}
+
+func TestInvalidDenyOSCannotBroadenRule(t *testing.T) {
+	builder := flatbuffers.NewBuilder(128)
+	offset, err := (JSONDeny{
+		Os:   "freebsd",
+		Cmds: []CmdPattern{"/usr/bin/curl"},
+	}).ConvertToWLS(builder)
+	if err == nil {
+		t.Fatalf("invalid OS was dropped, broadening the command deny rule at offset %d", offset)
+	}
+}
+
+func TestDenyOSUsesCanonicalMacOS(t *testing.T) {
+	for _, input := range []string{"darwin", "macos"} {
+		t.Run(input, func(t *testing.T) {
+			if got := convertedOSValue(t, input); got != "macos" {
+				t.Fatalf("converted OS = %q, want macos", got)
+			}
+		})
+	}
+}

--- a/go/examples/example_json_to_hardcoded_injector_policies/converter/path_values_test.go
+++ b/go/examples/example_json_to_hardcoded_injector_policies/converter/path_values_test.go
@@ -1,9 +1,9 @@
 package converter
 
 import (
-	wls "dd-fbs/schema/dd/wls"
 	"testing"
 
+	wls "github.com/DataDog/dd-policy-engine/go/schema/dd/wls"
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 


### PR DESCRIPTION
## What

Rejects unsupported operating-system values and normalizes both darwin and macos input to the canonical macos runtime value. Adds focused converter tests.

## Why

Unsupported OS input was silently dropped, broadening the remaining deny conditions, while darwin output never matched the runtime canonical value.

## Impact

Invalid OS requirements fail conversion and macOS deny rules match consistently.

## Validation

- Focused invalid-OS and macOS normalization tests
- go test ./...
- gofmt and diff checks

Part of #82