### PR TITLE
[codex] Return libc version validation errors

### DIFF
--- a/go/cmd/dd-requirements-converter/converter/libc.go
+++ b/go/cmd/dd-requirements-converter/converter/libc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/dd-policy-engine/go/schema"
@@ -31,8 +32,19 @@ func (rv *RequiredVersion) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if versionStr == "" {
-		return nil
+	versionStr = strings.TrimSpace(versionStr)
+	versionCore := versionStr
+	if suffix := strings.IndexAny(versionCore, "-+"); suffix >= 0 {
+		versionCore = versionCore[:suffix]
+	}
+	segments := strings.Split(versionCore, ".")
+	if len(segments) < 2 {
+		return fmt.Errorf("invalid libc version %q: expected at least major.minor", versionStr)
+	}
+	for _, segment := range segments[:2] {
+		if _, err := strconv.ParseUint(segment, 10, 64); err != nil {
+			return fmt.Errorf("invalid libc version %q: expected numeric major.minor", versionStr)
+		}
 	}
 
 	v, err := version.NewVersion(versionStr)
@@ -73,17 +85,7 @@ func (l JSONlibc) ConvertToWLS(builder *flatbuffers.Builder, flavor string) (fla
 	nodes = append(nodes, schema.NodeTypeWrapperCreate(builder, flavorNode, wls.NodeTypeEvaluatorNode))
 
 	if l.RequiredMinVersion != nil {
-		versionText := strings.TrimSpace(l.RequiredMinVersion.Original())
-		if suffix := strings.IndexAny(versionText, "-+"); suffix >= 0 {
-			versionText = versionText[:suffix]
-		}
-		if prerelease := l.RequiredMinVersion.Prerelease(); prerelease != "" {
-			versionText = strings.TrimSuffix(versionText, prerelease)
-		}
 		segments := l.RequiredMinVersion.Segments()
-		if strings.Count(versionText, ".") < 1 || len(segments) < 2 {
-			return 0, fmt.Errorf("invalid libc version %q: expected at least major.minor", versionText)
-		}
 
 		major := segments[0]
 		minor := segments[1]

--- a/go/cmd/dd-requirements-converter/converter/libc.go
+++ b/go/cmd/dd-requirements-converter/converter/libc.go
@@ -77,6 +77,9 @@ func (l JSONlibc) ConvertToWLS(builder *flatbuffers.Builder, flavor string) (fla
 		if suffix := strings.IndexAny(versionText, "-+"); suffix >= 0 {
 			versionText = versionText[:suffix]
 		}
+		if prerelease := l.RequiredMinVersion.Prerelease(); prerelease != "" {
+			versionText = strings.TrimSuffix(versionText, prerelease)
+		}
 		segments := l.RequiredMinVersion.Segments()
 		if strings.Count(versionText, ".") < 1 || len(segments) < 2 {
 			return 0, fmt.Errorf("invalid libc version %q: expected at least major.minor", versionText)

--- a/go/cmd/dd-requirements-converter/converter/libc.go
+++ b/go/cmd/dd-requirements-converter/converter/libc.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/DataDog/dd-policy-engine/go/schema"
@@ -33,27 +32,38 @@ func (rv *RequiredVersion) UnmarshalJSON(data []byte) error {
 	}
 
 	versionStr = strings.TrimSpace(versionStr)
-	versionCore := versionStr
-	if suffix := strings.IndexAny(versionCore, "-+"); suffix >= 0 {
-		versionCore = versionCore[:suffix]
-	}
-	segments := strings.Split(versionCore, ".")
-	if len(segments) < 2 {
-		return fmt.Errorf("invalid libc version %q: expected at least major.minor", versionStr)
-	}
-	for _, segment := range segments[:2] {
-		if _, err := strconv.ParseUint(segment, 10, 64); err != nil {
-			return fmt.Errorf("invalid libc version %q: expected numeric major.minor", versionStr)
-		}
-	}
-
 	v, err := version.NewVersion(versionStr)
 	if err != nil {
 		return err
 	}
+	if !hasMajorMinor(versionStr) {
+		return fmt.Errorf("invalid libc version %q: expected at least major.minor", versionStr)
+	}
 
 	*rv = RequiredVersion{Version: *v}
 	return nil
+}
+
+func hasMajorMinor(versionStr string) bool {
+	versionStr = strings.TrimPrefix(strings.TrimPrefix(versionStr, "v"), "V")
+	position := 0
+	for component := 0; component < 2; component++ {
+		start := position
+		for position < len(versionStr) && versionStr[position] >= '0' && versionStr[position] <= '9' {
+			position++
+		}
+		if position == start {
+			return false
+		}
+		if component == 1 {
+			return true
+		}
+		if position >= len(versionStr) || versionStr[position] != '.' {
+			return false
+		}
+		position++
+	}
+	return false
 }
 
 // ConvertToWLS converts a JSONlibc requirement to a WLS DENY policy.

--- a/go/cmd/dd-requirements-converter/converter/libc.go
+++ b/go/cmd/dd-requirements-converter/converter/libc.go
@@ -3,7 +3,8 @@ package converter
 import (
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
+	"strings"
 
 	"github.com/DataDog/dd-policy-engine/go/schema"
 	"github.com/DataDog/dd-policy-engine/go/schema/dd/wls"
@@ -72,10 +73,13 @@ func (l JSONlibc) ConvertToWLS(builder *flatbuffers.Builder, flavor string) (fla
 	nodes = append(nodes, schema.NodeTypeWrapperCreate(builder, flavorNode, wls.NodeTypeEvaluatorNode))
 
 	if l.RequiredMinVersion != nil {
+		versionText := strings.TrimSpace(l.RequiredMinVersion.Original())
+		if suffix := strings.IndexAny(versionText, "-+"); suffix >= 0 {
+			versionText = versionText[:suffix]
+		}
 		segments := l.RequiredMinVersion.Segments()
-
-		if len(segments) < 2 {
-			log.Fatalf("Invalid version: %v", l.RequiredMinVersion)
+		if strings.Count(versionText, ".") < 1 || len(segments) < 2 {
+			return 0, fmt.Errorf("invalid libc version %q: expected at least major.minor", versionText)
 		}
 
 		major := segments[0]

--- a/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
+++ b/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
@@ -13,6 +13,8 @@ func TestInvalidLibcVersionsFailUnmarshal(t *testing.T) {
 		{name: "empty"},
 		{name: "major only", version: "2"},
 		{name: "major only bare prerelease", version: "2rc.1"},
+		{name: "major only hyphenated prerelease", version: "2-rc.1"},
+		{name: "major only metadata", version: "2+build.1"},
 	}
 
 	for _, testCase := range testCases {
@@ -23,6 +25,26 @@ func TestInvalidLibcVersionsFailUnmarshal(t *testing.T) {
 				&requirement,
 			); err == nil {
 				t.Fatalf("expected version %q to fail unmarshalling", testCase.version)
+			}
+		})
+	}
+}
+
+func TestValidLibcVersionFormsUnmarshal(t *testing.T) {
+	testCases := []string{
+		"2.17",
+		"2.17rc.1",
+		"v2.17",
+	}
+
+	for _, version := range testCases {
+		t.Run(version, func(t *testing.T) {
+			var requirement JSONlibc
+			if err := json.Unmarshal(
+				[]byte(`{"arch":"x64","supported":true,"min":"`+version+`"}`),
+				&requirement,
+			); err != nil {
+				t.Fatalf("expected version %q to unmarshal: %v", version, err)
 			}
 		})
 	}

--- a/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
+++ b/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
@@ -1,0 +1,34 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+
+func TestInvalidLibcVersionsReturnErrors(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{name: "empty"},
+		{name: "major only", version: "2"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var requirement JSONlibc
+			if err := json.Unmarshal(
+				[]byte(`{"arch":"x64","supported":true,"min":"`+testCase.version+`"}`),
+				&requirement,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := requirement.ConvertToWLS(flatbuffers.NewBuilder(128), "glibc"); err == nil {
+				t.Fatalf("expected version %q to be rejected", testCase.version)
+			}
+		})
+	}
+}

--- a/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
+++ b/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
@@ -3,11 +3,9 @@ package converter
 import (
 	"encoding/json"
 	"testing"
-
-	flatbuffers "github.com/google/flatbuffers/go"
 )
 
-func TestInvalidLibcVersionsReturnErrors(t *testing.T) {
+func TestInvalidLibcVersionsFailUnmarshal(t *testing.T) {
 	testCases := []struct {
 		name    string
 		version string
@@ -23,12 +21,8 @@ func TestInvalidLibcVersionsReturnErrors(t *testing.T) {
 			if err := json.Unmarshal(
 				[]byte(`{"arch":"x64","supported":true,"min":"`+testCase.version+`"}`),
 				&requirement,
-			); err != nil {
-				t.Fatal(err)
-			}
-
-			if _, err := requirement.ConvertToWLS(flatbuffers.NewBuilder(128), "glibc"); err == nil {
-				t.Fatalf("expected version %q to be rejected", testCase.version)
+			); err == nil {
+				t.Fatalf("expected version %q to fail unmarshalling", testCase.version)
 			}
 		})
 	}

--- a/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
+++ b/go/cmd/dd-requirements-converter/converter/libc_version_validation_test.go
@@ -14,6 +14,7 @@ func TestInvalidLibcVersionsReturnErrors(t *testing.T) {
 	}{
 		{name: "empty"},
 		{name: "major only", version: "2"},
+		{name: "major only bare prerelease", version: "2rc.1"},
 	}
 
 	for _, testCase := range testCases {

--- a/go/examples/example_json_to_hardcoded_injector_policies/converter/path_values_test.go
+++ b/go/examples/example_json_to_hardcoded_injector_policies/converter/path_values_test.go
@@ -1,9 +1,9 @@
 package converter
 
 import (
-	wls "dd-fbs/schema/dd/wls"
 	"testing"
 
+	wls "github.com/DataDog/dd-policy-engine/go/schema/dd/wls"
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 


### PR DESCRIPTION
## What

Returns validation errors for empty and major-only libc versions instead of terminating the process. Adds focused regression coverage.

## Why

Invalid minimum versions reached log.Fatalf, which exited the converter and prevented callers from handling bad input.

## Impact

Converter callers receive ordinary validation errors and remain in control of process lifetime.

## Validation

- Focused TestInvalidLibcVersionsReturnErrors
- go test ./...
- gofmt and diff checks

Part of #82