### PR TITLE
fix: test_evaluator needs a UUID to compile

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,5 +1,9 @@
 name: Development
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [main]
 
 env: 
   # Override the `DOCKER_IMAGE` variable in Makefile.docker  

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1150,10 +1150,10 @@ static void build_pod_label_policy_buffer(const char *expected, void **out_buf, 
   dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_end(&b);
 
   /* Policy(description, rules, actions, id, version) */
-  dd_wls_Policy_ref_t policy = dd_wls_Policy_create(
-      &b, flatbuffers_string_create_str(&b, "k8s pod-label policy"), rules, actions,
-      flatbuffers_string_create_str(&b, "test-pod-label"), 1
-  );
+  dd_wls_UUID_t id;
+  dd_wls_UUID_assign(&id, 0, 0);
+  dd_wls_Policy_ref_t policy =
+      dd_wls_Policy_create(&b, flatbuffers_string_create_str(&b, "k8s pod-label policy"), rules, actions, &id, 1);
 
   dd_wls_Policy_vec_start(&b);
   dd_wls_Policy_vec_push(&b, policy);


### PR DESCRIPTION
Unfortunately this hasn't been caught by the CI because of concurrent modification on main and on PR.

This commit also enable the CI on main, to catch those issues earlier.