### PR TITLE
Describe the rule that triggered an action, including its context values

### DIFF
--- a/c/examples/basic-reader.c
+++ b/c/examples/basic-reader.c
@@ -67,9 +67,9 @@ plcs_errors ACTION_INJECT_DENY(
 ) {
   (void)policy_id;
   (void)policy_version;
-  (void)policy_description;
   printf("Action: DENY\n");
   printf("Description: '%s' (id: %d)\n", description, action_id);
+  printf("Matched rule: '%s'\n", policy_description);
   printf("Result: %s\n", res == PLCS_EVAL_RESULT_FALSE ? "false" : res == PLCS_EVAL_RESULT_TRUE ? "true" : "dont-care");
 
   for (size_t ix = 0; ix < value_len; ++ix) {
@@ -91,9 +91,9 @@ plcs_errors ACTION_INJECT_ALLOW(
 ) {
   (void)policy_id;
   (void)policy_version;
-  (void)policy_description;
   printf("Action: ALLOW\n");
   printf("Description: '%s' (id: %d)\n", description, action_id);
+  printf("Matched rule: '%s'\n", policy_description);
   printf("Result: %s\n", res == PLCS_EVAL_RESULT_FALSE ? "false" : res == PLCS_EVAL_RESULT_TRUE ? "true" : "dont-care");
 
   for (size_t ix = 0; ix < value_len; ++ix) {

--- a/c/examples/mmap-reader.c
+++ b/c/examples/mmap-reader.c
@@ -34,8 +34,8 @@ plcs_errors ACTION_INJECT_DENY(
 ) {
   (void)policy_id;
   (void)policy_version;
-  (void)policy_description;
   printf("Action: DENY\n");
+  printf("Matched rule: '%s'\n", policy_description);
   printf("Description: '%s' (id: %d)\n", description, action_id);
   printf("Result: %s\n", res == PLCS_EVAL_RESULT_FALSE ? "false" : res == PLCS_EVAL_RESULT_TRUE ? "true" : "dont-care");
 
@@ -58,8 +58,8 @@ plcs_errors ACTION_INJECT_ALLOW(
 ) {
   (void)policy_id;
   (void)policy_version;
-  (void)policy_description;
   printf("Action: ALLOW\n");
+  printf("Matched rule: '%s'\n", policy_description);
   printf("Description: '%s' (id: %d)\n", description, action_id);
   printf("Result: %s\n", res == PLCS_EVAL_RESULT_FALSE ? "false" : res == PLCS_EVAL_RESULT_TRUE ? "true" : "dont-care");
 

--- a/c/include/dd/policies/action.h
+++ b/c/include/dd/policies/action.h
@@ -48,7 +48,10 @@ typedef struct {
  * @param action_id           Integer ID of the action (a plcs_actions value).
  * @param policy_id           The id of the policy that produced this action.
  * @param policy_version      The version of the policy that produced this action.
- * @param policy_description  The description of the policy that produced this action.
+ * @param policy_description  The description of the rule that triggered this action: the
+ *                            descriptions of every condition of the matching AND node joined
+ *                            with " AND ", or the first matching condition of an OR node.
+ *                            Falls back to the policy's own description when no rule matched.
  *
  */
 typedef plcs_errors (*plcs_action_function_ptr)(

--- a/c/include/dd/policies/evaluator_types.h
+++ b/c/include/dd/policies/evaluator_types.h
@@ -11,20 +11,24 @@
 
 /**
  * @brief these are public represntations of the wire (flatbuffers) enums used in the policy engine
+ *
+ * Each entry of the X macro lists below is (ID, wire value, human readable label). The label is
+ * what the engine uses to describe a rule that matched, e.g. the PROCESS_EXE evaluator compared
+ * with CMP_PREFIX reads as "process executable 'python3.11' is prefixed with 'python'".
  */
 
 /**
  * @brief comparison operators for string evaluators
  */
 #define PLCS_LIST_STRING_COMPARATORS(X)                                                                                \
-  X(STR_UNKNOWN, 0)                                                                                                    \
-  X(PREFIX, 1)                                                                                                         \
-  X(SUFFIX, 2)                                                                                                         \
-  X(CONTAINS, 3)                                                                                                       \
-  X(EXACT, 4)                                                                                                          \
-  X(WILDCARD, 5)
+  X(STR_UNKNOWN, 0, "compares to")                                                                                     \
+  X(PREFIX, 1, "is prefixed with")                                                                                     \
+  X(SUFFIX, 2, "is suffixed with")                                                                                     \
+  X(CONTAINS, 3, "contains")                                                                                           \
+  X(EXACT, 4, "is")                                                                                                    \
+  X(WILDCARD, 5, "matches")
 
-#define ENUM_COMPARATOR_VAL(VAL, IX) PLCS_STR_CMP_##VAL = IX,
+#define ENUM_COMPARATOR_VAL(VAL, IX, LABEL) PLCS_STR_CMP_##VAL = IX,
 typedef enum plcs_string_comparator {
   PLCS_LIST_STRING_COMPARATORS(ENUM_COMPARATOR_VAL) PLCS_STR_CMP__COUNT
 } plcs_string_comparator;
@@ -34,14 +38,14 @@ typedef enum plcs_string_comparator {
  * @brief comparison operators for numeric (and unsigned numeric) evaluators
  */
 #define PLCS_LIST_NUMERIC_COMPARATOR(X)                                                                                \
-  X(NUM_UNKNOWN, 0)                                                                                                    \
-  X(EQ, 1)                                                                                                             \
-  X(GT, 2)                                                                                                             \
-  X(GTE, 3)                                                                                                            \
-  X(LT, 4)                                                                                                             \
-  X(LTE, 5)
+  X(NUM_UNKNOWN, 0, "compares to")                                                                                     \
+  X(EQ, 1, "is")                                                                                                       \
+  X(GT, 2, "is greater than")                                                                                          \
+  X(GTE, 3, "is at least")                                                                                             \
+  X(LT, 4, "is less than")                                                                                             \
+  X(LTE, 5, "is at most")
 
-#define ENUM_NUMERIC_VAL(VAL, IX) PLCS_NUM_CMP_##VAL = IX,
+#define ENUM_NUMERIC_VAL(VAL, IX, LABEL) PLCS_NUM_CMP_##VAL = IX,
 typedef enum plcs_numeric_comparator {
   PLCS_LIST_NUMERIC_COMPARATOR(ENUM_NUMERIC_VAL) PLCS_NUM_CMP__COUNT
 } plcs_numeric_comparator;
@@ -52,64 +56,64 @@ typedef enum plcs_numeric_comparator {
  * These represent the supported string evaluators by the policy engine.
  */
 #define PLCS_LIST_STRING_EVALUATORS(X)                                                                                 \
-  X(STRING_EVAL_UNKNOWN, 0)                                                                                            \
-  X(COMPONENT, 1)                                                                                                      \
-  X(PROCESS_EXE, 2)                                                                                                    \
-  X(PROCESS_EXE_FULL_PATH, 3)                                                                                          \
-  X(PROCESS_BASEDIR_PATH, 4)                                                                                           \
-  X(PROCESS_ARGV, 5)                                                                                                   \
-  X(PROCESS_CWD, 6)                                                                                                    \
-  X(RUNTIME_LANGUAGE, 7)                                                                                               \
-  X(RUNTIME_ENTRY_POINT_FILE, 8)                                                                                       \
-  X(RUNTIME_ENTRY_POINT_JAR, 9)                                                                                        \
-  X(RUNTIME_ENTRY_POINT_CLASS, 10)                                                                                     \
-  X(RUNTIME_ENTRY_POINT_PACKAGE, 11)                                                                                   \
-  X(RUNTIME_ENTRY_POINT_MODULE, 12)                                                                                    \
-  X(RUNTIME_ENTRY_POINT_SOURCE, 13)                                                                                    \
-  X(RUNTIME_DOPTION, 14)                                                                                               \
-  X(RUNTIME_VERSION, 15)                                                                                               \
-  X(LIBC_FLAVOR, 16)                                                                                                   \
-  X(LIBC_VERSION, 17)                                                                                                  \
-  X(MACHINE_ARCHITECTURE, 18)                                                                                          \
-  X(HOST_NAME, 19)                                                                                                     \
-  X(HOST_IP, 20)                                                                                                       \
-  X(OS, 21)                                                                                                            \
-  X(OS_DISTRO, 22)                                                                                                     \
-  X(OS_DISTRO_VERSION, 23)                                                                                             \
-  X(OS_DISTRO_CODENAME, 24)                                                                                            \
-  X(OS_KERNEL_VERSION, 25)                                                                                             \
-  X(OS_KERNEL_NAME, 26)                                                                                                \
-  X(OS_USER, 27)                                                                                                       \
-  X(OS_USER_GROUP, 28)                                                                                                 \
-  X(CONTAINER_IMAGE, 29)                                                                                               \
-  X(CONTAINER_ID, 30)                                                                                                  \
-  X(ALWAYS_TRUE, 31)                                                                                                   \
-  X(ALWAYS_FALSE, 32)                                                                                                  \
-  X(ALWAYS_ABSTAIN, 33)                                                                                                \
-  X(IIS_APPLICATION_POOL, 34)                                                                                          \
-  X(PROCESS_ARGV_0, 35)                                                                                                \
-  X(PROCESS_ARGV_1, 36)                                                                                                \
-  X(PROCESS_ARGV_2, 37)                                                                                                \
-  X(PROCESS_ARGV_3, 38)                                                                                                \
-  X(PROCESS_ARGV_4, 39)                                                                                                \
-  X(PROCESS_ARGV_5, 40)                                                                                                \
-  X(PROCESS_ARGV_N, 41)                                                                                                \
-  X(PROCESS_ARGV_N_2, 42)                                                                                              \
-  X(PROCESS_ARGV_N_3, 43)                                                                                              \
-  X(PROCESS_ARGV_N_4, 44)                                                                                              \
-  X(PROCESS_ARGV_N_5, 45)                                                                                              \
-  X(PROCESS_ARGV_N_6, 46)                                                                                              \
-  X(PROCESS_ENVAR, 47)                                                                                                 \
-  X(CONTAINER_IMAGE_TAG, 48)                                                                                           \
-  X(CONTAINER_IMAGE_DIGEST, 49)                                                                                        \
-  X(CONTAINER_NAME, 50)                                                                                                \
-  X(CONTAINER_LABEL, 51)                                                                                               \
-  X(NAMESPACE_NAME, 52)                                                                                                \
-  X(NAMESPACE_LABEL, 53)                                                                                               \
-  X(POD_LABEL, 54)                                                                                                     \
-  X(POD_ANNOTATION, 55)
+  X(STRING_EVAL_UNKNOWN, 0, "unknown value")                                                                           \
+  X(COMPONENT, 1, "component")                                                                                         \
+  X(PROCESS_EXE, 2, "process executable")                                                                              \
+  X(PROCESS_EXE_FULL_PATH, 3, "process executable full path")                                                          \
+  X(PROCESS_BASEDIR_PATH, 4, "process base directory path")                                                            \
+  X(PROCESS_ARGV, 5, "process arguments")                                                                              \
+  X(PROCESS_CWD, 6, "process working directory")                                                                       \
+  X(RUNTIME_LANGUAGE, 7, "runtime language")                                                                           \
+  X(RUNTIME_ENTRY_POINT_FILE, 8, "runtime entry point file")                                                           \
+  X(RUNTIME_ENTRY_POINT_JAR, 9, "runtime entry point jar")                                                             \
+  X(RUNTIME_ENTRY_POINT_CLASS, 10, "runtime entry point class")                                                        \
+  X(RUNTIME_ENTRY_POINT_PACKAGE, 11, "runtime entry point package")                                                    \
+  X(RUNTIME_ENTRY_POINT_MODULE, 12, "runtime entry point module")                                                      \
+  X(RUNTIME_ENTRY_POINT_SOURCE, 13, "runtime entry point source")                                                      \
+  X(RUNTIME_DOPTION, 14, "runtime -D option")                                                                          \
+  X(RUNTIME_VERSION, 15, "runtime version")                                                                            \
+  X(LIBC_FLAVOR, 16, "libc flavor")                                                                                    \
+  X(LIBC_VERSION, 17, "libc version")                                                                                  \
+  X(MACHINE_ARCHITECTURE, 18, "machine architecture")                                                                  \
+  X(HOST_NAME, 19, "host name")                                                                                        \
+  X(HOST_IP, 20, "host IP")                                                                                            \
+  X(OS, 21, "operating system")                                                                                        \
+  X(OS_DISTRO, 22, "OS distribution")                                                                                  \
+  X(OS_DISTRO_VERSION, 23, "OS distribution version")                                                                  \
+  X(OS_DISTRO_CODENAME, 24, "OS distribution codename")                                                                \
+  X(OS_KERNEL_VERSION, 25, "OS kernel version")                                                                        \
+  X(OS_KERNEL_NAME, 26, "OS kernel name")                                                                              \
+  X(OS_USER, 27, "OS user")                                                                                            \
+  X(OS_USER_GROUP, 28, "OS user group")                                                                                \
+  X(CONTAINER_IMAGE, 29, "container image")                                                                            \
+  X(CONTAINER_ID, 30, "container id")                                                                                  \
+  X(ALWAYS_TRUE, 31, "always true")                                                                                    \
+  X(ALWAYS_FALSE, 32, "always false")                                                                                  \
+  X(ALWAYS_ABSTAIN, 33, "always abstain")                                                                              \
+  X(IIS_APPLICATION_POOL, 34, "IIS application pool")                                                                  \
+  X(PROCESS_ARGV_0, 35, "process argument 0")                                                                          \
+  X(PROCESS_ARGV_1, 36, "process argument 1")                                                                          \
+  X(PROCESS_ARGV_2, 37, "process argument 2")                                                                          \
+  X(PROCESS_ARGV_3, 38, "process argument 3")                                                                          \
+  X(PROCESS_ARGV_4, 39, "process argument 4")                                                                          \
+  X(PROCESS_ARGV_5, 40, "process argument 5")                                                                          \
+  X(PROCESS_ARGV_N, 41, "last process argument")                                                                       \
+  X(PROCESS_ARGV_N_2, 42, "2nd to last process argument")                                                              \
+  X(PROCESS_ARGV_N_3, 43, "3rd to last process argument")                                                              \
+  X(PROCESS_ARGV_N_4, 44, "4th to last process argument")                                                              \
+  X(PROCESS_ARGV_N_5, 45, "5th to last process argument")                                                              \
+  X(PROCESS_ARGV_N_6, 46, "6th to last process argument")                                                              \
+  X(PROCESS_ENVAR, 47, "process environment variable")                                                                 \
+  X(CONTAINER_IMAGE_TAG, 48, "container image tag")                                                                    \
+  X(CONTAINER_IMAGE_DIGEST, 49, "container image digest")                                                              \
+  X(CONTAINER_NAME, 50, "container name")                                                                              \
+  X(CONTAINER_LABEL, 51, "container label")                                                                            \
+  X(NAMESPACE_NAME, 52, "namespace name")                                                                              \
+  X(NAMESPACE_LABEL, 53, "namespace label")                                                                            \
+  X(POD_LABEL, 54, "pod label")                                                                                        \
+  X(POD_ANNOTATION, 55, "pod annotation")
 
-#define ENUM_STR_CMP_EVAL(ID, IX) PLCS_STR_EVAL_##ID = IX,
+#define ENUM_STR_CMP_EVAL(ID, IX, LABEL) PLCS_STR_EVAL_##ID = IX,
 typedef enum plcs_string_evaluators {
   PLCS_LIST_STRING_EVALUATORS(ENUM_STR_CMP_EVAL) PLCS_STR_EVAL__COUNT
 } plcs_string_evaluators;
@@ -120,22 +124,22 @@ typedef enum plcs_string_evaluators {
  * These represent the supported numeric evaluators by the policy engine.
  */
 #define PLCS_LIST_NUMERIC_EVALUATORS(X)                                                                                \
-  X(NUMERIC_EVAL_UNKNOWN, 0)                                                                                           \
-  X(JAVA_HEAP, 1)                                                                                                      \
-  X(RUNTIME_VERSION_MAJOR, 2)                                                                                          \
-  X(RUNTIME_VERSION_MINOR, 3)                                                                                          \
-  X(RUNTIME_VERSION_PATCH, 4)                                                                                          \
-  X(OS_DISTRO_VERSION_MAJOR, 5)                                                                                        \
-  X(OS_DISTRO_VERSION_MINOR, 6)                                                                                        \
-  X(OS_DISTRO_VERSION_PATCH, 7)                                                                                        \
-  X(OS_KERNEL_VERSION_MAJOR, 8)                                                                                        \
-  X(OS_KERNEL_VERSION_MINOR, 9)                                                                                        \
-  X(OS_KERNEL_VERSION_PATCH, 10)                                                                                       \
-  X(LIBC_VERSION_MAJOR, 11)                                                                                            \
-  X(LIBC_VERSION_MINOR, 12)                                                                                            \
-  X(LIBC_VERSION_PATCH, 13)
+  X(NUMERIC_EVAL_UNKNOWN, 0, "unknown value")                                                                          \
+  X(JAVA_HEAP, 1, "java heap")                                                                                         \
+  X(RUNTIME_VERSION_MAJOR, 2, "runtime major version")                                                                 \
+  X(RUNTIME_VERSION_MINOR, 3, "runtime minor version")                                                                 \
+  X(RUNTIME_VERSION_PATCH, 4, "runtime patch version")                                                                 \
+  X(OS_DISTRO_VERSION_MAJOR, 5, "OS distribution major version")                                                       \
+  X(OS_DISTRO_VERSION_MINOR, 6, "OS distribution minor version")                                                       \
+  X(OS_DISTRO_VERSION_PATCH, 7, "OS distribution patch version")                                                       \
+  X(OS_KERNEL_VERSION_MAJOR, 8, "OS kernel major version")                                                             \
+  X(OS_KERNEL_VERSION_MINOR, 9, "OS kernel minor version")                                                             \
+  X(OS_KERNEL_VERSION_PATCH, 10, "OS kernel patch version")                                                            \
+  X(LIBC_VERSION_MAJOR, 11, "libc major version")                                                                      \
+  X(LIBC_VERSION_MINOR, 12, "libc minor version")                                                                      \
+  X(LIBC_VERSION_PATCH, 13, "libc patch version")
 
-#define ENUM_STR_EVAL(ID, IX) PLCS_NUM_EVAL_##ID = IX,
+#define ENUM_STR_EVAL(ID, IX, LABEL) PLCS_NUM_EVAL_##ID = IX,
 typedef enum plcs_numeric_evaluators {
   PLCS_LIST_NUMERIC_EVALUATORS(ENUM_STR_EVAL) PLCS_NUM_EVAL__COUNT
 } plcs_numeric_evaluators;

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -12,6 +12,7 @@
 #include <dd/policies/policies.h>
 
 #include <stdio.h>
+#include <string.h>
 #include "eval_ctx.h"
 #include "policy.h"
 #include "wire/action.h"
@@ -19,8 +20,196 @@
 #include "wire/dd_types.h"
 #include "wire/evaluation_result.h"
 #define PLCS_MAX_EVAL_DEPTH 64
+#define PLCS_MATCHED_RULE_MAX 512
 
-plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth);
+/* Description of the rule that made a policy match, assembled while the tree is
+ * evaluated. Each condition is described from the evaluator itself, so it reports the context value it saw:
+ * "process executable 'python3.11' is prefixed with 'python'".
+ *
+ * A node only describes itself when it evaluates to TRUE, and a composite joins
+ * whatever its children described with its own operator. Since AND is only TRUE when
+ * every child is TRUE, and OR short circuits on the first TRUE child, this yields
+ * "every condition" for AND and "the first matching condition" for OR. */
+typedef struct {
+  char buf[PLCS_MATCHED_RULE_MAX];
+  size_t len;
+} plcs_matched_rule;
+
+/* Scratch space for one formatted condition. Deliberately one byte longer than the rule
+ * buffer, so that a condition too long to format here is also too long for the rule buffer:
+ * matched_rule_append is then guaranteed to notice, which keeps truncation handling in one
+ * place. */
+#define PLCS_CONDITION_MAX (PLCS_MATCHED_RULE_MAX + 1)
+
+// Appends as much of `text` as still fits. A description that does not fit is truncated with "..." at the end
+static void matched_rule_append(plcs_matched_rule *rule, const char *text) {
+  if (!rule || !text) {
+    return;
+  }
+
+  static const char ellipsis[] = "...";
+
+  size_t room = sizeof(rule->buf) - rule->len - 1;
+  size_t len = strlen(text);
+
+  if (len <= room) {
+    memcpy(rule->buf + rule->len, text, len);
+    rule->len += len;
+    rule->buf[rule->len] = '\0';
+    return;
+  }
+
+  memcpy(rule->buf + rule->len, text, room);
+  rule->len += room;
+  rule->buf[rule->len] = '\0';
+
+  size_t marker_len = sizeof(ellipsis) - 1;
+  size_t at = rule->len > marker_len ? rule->len - marker_len : 0;
+  memcpy(rule->buf + at, ellipsis, rule->len - at);
+}
+
+// drops everything appended past `len`; used to undo branches that did not match
+static void matched_rule_truncate(plcs_matched_rule *rule, size_t len) {
+  if (!rule) {
+    return;
+  }
+
+  rule->len = len;
+  rule->buf[len] = '\0';
+}
+
+static size_t matched_rule_len(const plcs_matched_rule *rule) {
+  return rule ? rule->len : 0;
+}
+
+// human readable labels for the evaluators and comparators
+#define PLCS_STR_EVAL_LABEL(ID, IX, LABEL) [PLCS_STR_EVAL_##ID] = LABEL,
+#define PLCS_NUM_EVAL_LABEL(ID, IX, LABEL) [PLCS_NUM_EVAL_##ID] = LABEL,
+#define PLCS_STR_CMP_LABEL(ID, IX, LABEL) [PLCS_STR_CMP_##ID] = LABEL,
+#define PLCS_NUM_CMP_LABEL(ID, IX, LABEL) [PLCS_NUM_CMP_##ID] = LABEL,
+
+static const char *const string_evaluator_labels[PLCS_STR_EVAL__COUNT] = {
+    PLCS_LIST_STRING_EVALUATORS(PLCS_STR_EVAL_LABEL)
+};
+static const char *const numeric_evaluator_labels[PLCS_NUM_EVAL__COUNT] = {
+    PLCS_LIST_NUMERIC_EVALUATORS(PLCS_NUM_EVAL_LABEL)
+};
+static const char *const string_comparator_labels[PLCS_STR_CMP__COUNT] = {
+    PLCS_LIST_STRING_COMPARATORS(PLCS_STR_CMP_LABEL)
+};
+static const char *const numeric_comparator_labels[PLCS_NUM_CMP__COUNT] = {
+    PLCS_LIST_NUMERIC_COMPARATOR(PLCS_NUM_CMP_LABEL)
+};
+
+#undef PLCS_STR_EVAL_LABEL
+#undef PLCS_NUM_EVAL_LABEL
+#undef PLCS_STR_CMP_LABEL
+#undef PLCS_NUM_CMP_LABEL
+
+static const char *label_at(const char *const labels[], size_t count, unsigned id) {
+  const char *label = id < count ? labels[id] : NULL;
+  return label ? label : labels[0];
+}
+
+static const char *string_evaluator_label(plcs_string_evaluators eval_id) {
+  return label_at(string_evaluator_labels, PLCS_STR_EVAL__COUNT, (unsigned)eval_id);
+}
+
+static const char *numeric_evaluator_label(plcs_numeric_evaluators eval_id) {
+  return label_at(numeric_evaluator_labels, PLCS_NUM_EVAL__COUNT, (unsigned)eval_id);
+}
+
+static const char *string_comparator_label(plcs_string_comparator cmp) {
+  return label_at(string_comparator_labels, PLCS_STR_CMP__COUNT, (unsigned)cmp);
+}
+
+static const char *numeric_comparator_label(plcs_numeric_comparator cmp) {
+  return label_at(numeric_comparator_labels, PLCS_NUM_CMP__COUNT, (unsigned)cmp);
+}
+
+
+// appends to matched rule with description like "process executable 'python3.11' is prefixed with 'python'", or "runtime language is 'java'" */
+static void matched_rule_describe_string(plcs_matched_rule *rule, dd_ns(StrEvaluator_table_t) eval_str) {
+  plcs_string_evaluators eval_id = (plcs_string_evaluators)dd_ns(StrEvaluator_id)(eval_str);
+  plcs_string_comparator cmp = (plcs_string_comparator)dd_ns(StrEvaluator_cmp)(eval_str);
+  const char *param = plcs_eval_ctx_get_string_param(eval_id);
+  const char *value = dd_ns(StrEvaluator_value)(eval_str);
+  char text[PLCS_CONDITION_MAX];
+
+  param = param ? param : "";
+  value = value ? value : "";
+
+  if (cmp == PLCS_STR_CMP_EXACT && strcmp(param, value) == 0) {
+    snprintf(text, sizeof(text), "%s is '%s'", string_evaluator_label(eval_id), value);
+  } else {
+    snprintf(
+        text, sizeof(text), "%s '%s' %s '%s'", string_evaluator_label(eval_id), param, string_comparator_label(cmp),
+        value
+    );
+  }
+
+  matched_rule_append(rule, text);
+}
+
+// appends to matched rule with description like "java heap 512 is greater than 256", or "runtime major version is 21" */
+static void matched_rule_describe_numeric(plcs_matched_rule *rule, dd_ns(NumEvaluator_table_t) eval_num) {
+  plcs_numeric_evaluators eval_id = (plcs_numeric_evaluators)dd_ns(NumEvaluator_id)(eval_num);
+  plcs_numeric_comparator cmp = (plcs_numeric_comparator)dd_ns(NumEvaluator_cmp)(eval_num);
+  long param = plcs_eval_ctx_get_numeric_param(eval_id);
+  long value = (long)dd_ns(NumEvaluator_value)(eval_num);
+  char text[PLCS_CONDITION_MAX];
+
+  if (cmp == PLCS_NUM_CMP_EQ && param == value) {
+    snprintf(text, sizeof(text), "%s is %ld", numeric_evaluator_label(eval_id), value);
+  } else {
+    snprintf(
+        text, sizeof(text), "%s %ld %s %ld", numeric_evaluator_label(eval_id), param, numeric_comparator_label(cmp),
+        value
+    );
+  }
+
+  matched_rule_append(rule, text);
+}
+
+static void matched_rule_describe_unumeric(plcs_matched_rule *rule, dd_ns(UNumEvaluator_table_t) eval_unum) {
+  plcs_numeric_evaluators eval_id = (plcs_numeric_evaluators)dd_ns(UNumEvaluator_id)(eval_unum);
+  plcs_numeric_comparator cmp = (plcs_numeric_comparator)dd_ns(UNumEvaluator_cmp)(eval_unum);
+  unsigned long param = plcs_eval_ctx_get_unumeric_param(eval_id);
+  unsigned long value = (unsigned long)dd_ns(UNumEvaluator_value)(eval_unum);
+  char text[PLCS_CONDITION_MAX];
+
+  if (cmp == PLCS_NUM_CMP_EQ && param == value) {
+    snprintf(text, sizeof(text), "%s is %lu", numeric_evaluator_label(eval_id), value);
+  } else {
+    snprintf(
+        text, sizeof(text), "%s %lu %s %lu", numeric_evaluator_label(eval_id), param, numeric_comparator_label(cmp),
+        value
+    );
+  }
+
+  matched_rule_append(rule, text);
+}
+
+/* Describes the condition a leaf node checked, along with the context value it saw. */
+static void matched_rule_describe_node(plcs_matched_rule *rule, dd_ns(EvaluatorNode_table_t) node) {
+  dd_ns(EvaluatorType_union_t) evaluator = dd_ns(EvaluatorNode_eval_union)(node);
+
+  switch (evaluator.type) {
+    case dd_ns(EvaluatorType_StrEvaluator):
+      matched_rule_describe_string(rule, evaluator.value);
+      break;
+
+    case dd_ns(EvaluatorType_NumEvaluator):
+      matched_rule_describe_numeric(rule, evaluator.value);
+      break;
+
+    case dd_ns(EvaluatorType_UNumEvaluator):
+      matched_rule_describe_unumeric(rule, evaluator.value);
+      break;
+  }
+}
+
+plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth, plcs_matched_rule *rule);
 
 plcs_evaluation_result evaluate_string(dd_ns(StrEvaluator_table_t) eval_str, const char *description) {
   if (!eval_str) {
@@ -176,7 +365,7 @@ plcs_evaluation_result DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_
   }
 }
 
-plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth) {
+plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth, plcs_matched_rule *rule) {
   if (!node) {
     return PLCS_EVAL_RESULT_ABSTAIN;
   }
@@ -207,29 +396,56 @@ plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, in
         // log error
         return PLCS_EVAL_RESULT_ABSTAIN;
       }
-      return DoNot(evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, 0), depth + 1));
-      break;
+      dd_ns(NodeTypeWrapper_table_t) negated = dd_ns(NodeTypeWrapper_vec_at)(children, 0);
+      res = DoNot(evaluate_rules(negated, depth + 1, NULL));
+      // the child is what did *not* match, so describe it negated. A negated composite has
+      // no single condition to point at, so it is left to the policy description instead.
+      if (res == PLCS_EVAL_RESULT_TRUE && dd_ns(NodeTypeWrapper_node_type)(negated) == dd_ns(NodeType_EvaluatorNode)) {
+        matched_rule_append(rule, "NOT (");
+        matched_rule_describe_node(rule, dd_ns(NodeTypeWrapper_node)(negated));
+        matched_rule_append(rule, ")");
+      }
+      return res;
   }
+
+  const char *separator = oper == dd_ns(BoolOperation_BOOL_AND) ? " AND " : " OR ";
+  const size_t rule_start = matched_rule_len(rule);
 
   // keep iterating recursively over the tree
   for (size_t ix = 0; ix < children_len; ++ix) {
-    res = DoOper(oper, res, evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1));
+    const size_t before_separator = matched_rule_len(rule);
+    if (before_separator > rule_start) {
+      matched_rule_append(rule, separator);
+    }
+    const size_t before_child = matched_rule_len(rule);
+
+    res = DoOper(oper, res, evaluate_rules(dd_ns(NodeTypeWrapper_vec_at)(children, ix), depth + 1, rule));
+
+    // the child had nothing to describe, so drop the separator we added for it
+    if (matched_rule_len(rule) == before_child) {
+      matched_rule_truncate(rule, before_separator);
+    }
 
     // short circuit
     if (oper == dd_ns(BoolOperation_BOOL_OR) && res == PLCS_EVAL_RESULT_TRUE) {
-      return res;
+      break;
     }
 
     // short circuit
     if (oper == dd_ns(BoolOperation_BOOL_AND) && res == PLCS_EVAL_RESULT_FALSE) {
-      return res;
+      break;
     }
+  }
+
+  // this branch did not match, so it is not part of the rule that triggered
+  if (res != PLCS_EVAL_RESULT_TRUE) {
+    matched_rule_truncate(rule, rule_start);
   }
 
   return res;
 }
 
-plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth) {
+plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int depth, plcs_matched_rule *rule) {
   if (depth > PLCS_MAX_EVAL_DEPTH) {
     return PLCS_EVAL_RESULT_ABSTAIN;
   }
@@ -237,12 +453,16 @@ plcs_evaluation_result evaluate_rules(dd_ns(NodeTypeWrapper_table_t) node, int d
   switch (dd_ns(NodeTypeWrapper_node_type)(node)) {
     case dd_ns(NodeType_EvaluatorNode):
       dd_ns(EvaluatorNode_table_t) evaluator_node = dd_ns(NodeTypeWrapper_node)(node);
-      return node_evaluator(evaluator_node);
+      plcs_evaluation_result res = node_evaluator(evaluator_node);
+      if (res == PLCS_EVAL_RESULT_TRUE) {
+        matched_rule_describe_node(rule, evaluator_node);
+      }
+      return res;
       break;
 
     case dd_ns(NodeType_CompositeNode):
       dd_ns(CompositeNode_table_t) composite_node = dd_ns(NodeTypeWrapper_node)(node);
-      return composite_evaluator(composite_node, depth);
+      return composite_evaluator(composite_node, depth, rule);
       break;
 
     default:
@@ -309,12 +529,15 @@ plcs_errors evaluate_policy(dd_ns(Policy_table_t) policy) {
   dd_ns(NodeTypeWrapper_table_t) rules = dd_ns(Policy_rules)(policy);
 
   // // evaluate rules if they exist, otherwise return EVAL_RESULT_ABSTAIN
-  plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0) : PLCS_EVAL_RESULT_ABSTAIN;
+  plcs_matched_rule matched_rule = {.buf = {'\0'}, .len = 0};
+  plcs_evaluation_result eval_res = rules ? evaluate_rules(rules, 0, &matched_rule) : PLCS_EVAL_RESULT_ABSTAIN;
+
+  // description describes the rule that triggered the actions, while falling
+  // back to the policy's own description when nothing matched
+  const char *description = matched_rule.len > 0 ? matched_rule.buf : dd_ns(Policy_description)(policy);
 
   // perform actions given evaluation result
-  return perform_actions(
-      eval_res, actions, policy_id, dd_ns(Policy_version)(policy), dd_ns(Policy_description)(policy)
-  );
+  return perform_actions(eval_res, actions, policy_id, dd_ns(Policy_version)(policy), description);
 }
 
 plcs_errors plcs_evaluate_buffer(const uint8_t *buffer, size_t size) {

--- a/c/src/evaluator.c
+++ b/c/src/evaluator.c
@@ -127,8 +127,8 @@ static const char *numeric_comparator_label(plcs_numeric_comparator cmp) {
   return label_at(numeric_comparator_labels, PLCS_NUM_CMP__COUNT, (unsigned)cmp);
 }
 
-
-// appends to matched rule with description like "process executable 'python3.11' is prefixed with 'python'", or "runtime language is 'java'" */
+// appends to matched rule with description like "process executable 'python3.11' is prefixed with 'python'", or
+// "runtime language is 'java'" */
 static void matched_rule_describe_string(plcs_matched_rule *rule, dd_ns(StrEvaluator_table_t) eval_str) {
   plcs_string_evaluators eval_id = (plcs_string_evaluators)dd_ns(StrEvaluator_id)(eval_str);
   plcs_string_comparator cmp = (plcs_string_comparator)dd_ns(StrEvaluator_cmp)(eval_str);
@@ -151,7 +151,8 @@ static void matched_rule_describe_string(plcs_matched_rule *rule, dd_ns(StrEvalu
   matched_rule_append(rule, text);
 }
 
-// appends to matched rule with description like "java heap 512 is greater than 256", or "runtime major version is 21" */
+// appends to matched rule with description like "java heap 512 is greater than 256", or "runtime major version is 21"
+// */
 static void matched_rule_describe_numeric(plcs_matched_rule *rule, dd_ns(NumEvaluator_table_t) eval_num) {
   plcs_numeric_evaluators eval_id = (plcs_numeric_evaluators)dd_ns(NumEvaluator_id)(eval_num);
   plcs_numeric_comparator cmp = (plcs_numeric_comparator)dd_ns(NumEvaluator_cmp)(eval_num);

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1280,15 +1280,7 @@ UTEST(evaluator_integration, evaluate_pod_label_policy_end_to_end_no_match) {
  * generates descriptions from the evaluators instead, so this must never show up. */
 #define UNUSED_AUTHORED_DESCRIPTION "authored description that must be ignored"
 
-/* Serialize a one-policy buffer whose rules are:                                  */
-/*                                                                                 */
-/*   CompositeNode(BOOL_AND)                                                       */
-/*     ├─ CompositeNode(BOOL_OR)                                                   */
-/*     │    ├─ StrEvaluator(PROCESS_EXE, CMP_EXACT,  "java")                       */
-/*     │    └─ StrEvaluator(PROCESS_EXE, CMP_PREFIX, "python")                     */
-/*     └─ StrEvaluator(RUNTIME_LANGUAGE, CMP_EXACT,  "java")                       */
-/*                                                                                 */
-/* Caller owns *out_buf (flatcc_builder_free). */
+// Builds a single StrEvaluator leaf node
 static dd_wls_NodeTypeWrapper_ref_t build_str_leaf(
     flatcc_builder_t *b,
     dd_wls_StringEvaluators_enum_t evaluator,
@@ -1321,6 +1313,15 @@ static dd_wls_NodeTypeWrapper_ref_t build_composite(
   );
 }
 
+/* Serialize a one-policy buffer whose rules are:                                  */
+/*                                                                                 */
+/*   CompositeNode(BOOL_AND)                                                       */
+/*     ├─ CompositeNode(BOOL_OR)                                                   */
+/*     │    ├─ StrEvaluator(PROCESS_EXE, CMP_EXACT,  "java")                       */
+/*     │    └─ StrEvaluator(PROCESS_EXE, CMP_PREFIX, "javac")                      */
+/*     └─ StrEvaluator(RUNTIME_LANGUAGE, CMP_EXACT,  "java")                       */
+/*                                                                                 */
+/* Caller owns *out_buf. */
 static void build_and_of_or_policy_buffer(void **out_buf, size_t *out_sz) {
   flatcc_builder_t b;
   flatcc_builder_init(&b);

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1390,8 +1390,7 @@ UTEST(evaluator_integration, matched_rule_joins_and_children_and_takes_first_tru
   /* The AND node contributes both of its children; the OR node contributes only the
    * "javac" branch, since the "java" exact branch evaluated to FALSE. */
   ASSERT_STREQ(
-      g_last_policy_description,
-      "process executable 'javac17' is prefixed with 'javac' AND runtime language is 'java'"
+      g_last_policy_description, "process executable 'javac17' is prefixed with 'javac' AND runtime language is 'java'"
   );
 
   flatcc_builder_free(buf);

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1328,7 +1328,7 @@ static void build_and_of_or_policy_buffer(void **out_buf, size_t *out_sz) {
   dd_wls_NodeTypeWrapper_ref_t or_wrap = build_composite(
       &b, dd_wls_BoolOperation_BOOL_OR,
       build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_EXACT, "java"),
-      build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_PREFIX, "python")
+      build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_PREFIX, "javac")
   );
   dd_wls_NodeTypeWrapper_ref_t language_wrap =
       build_str_leaf(&b, dd_wls_StringEvaluators_RUNTIME_LANGUAGE, dd_wls_CmpTypeSTR_CMP_EXACT, "java");
@@ -1377,7 +1377,7 @@ static int setup_and_of_or_policy_context(const char *process_exe, const char *l
 }
 
 UTEST(evaluator_integration, matched_rule_joins_and_children_and_takes_first_true_or_child) {
-  ASSERT_EQ(setup_and_of_or_policy_context("python3.11", "java"), PLCS_ESUCCESS);
+  ASSERT_EQ(setup_and_of_or_policy_context("javac17", "java"), PLCS_ESUCCESS);
 
   void *buf = NULL;
   size_t sz = 0;
@@ -1388,10 +1388,10 @@ UTEST(evaluator_integration, matched_rule_joins_and_children_and_takes_first_tru
   ASSERT_EQ(g_allow_called, 1);
   ASSERT_EQ((int)g_last_action_res, (int)PLCS_EVAL_RESULT_TRUE);
   /* The AND node contributes both of its children; the OR node contributes only the
-   * "python" branch, since the "java" branch evaluated to FALSE. */
+   * "javac" branch, since the "java" exact branch evaluated to FALSE. */
   ASSERT_STREQ(
       g_last_policy_description,
-      "process executable 'python3.11' is prefixed with 'python' AND runtime language is 'java'"
+      "process executable 'javac17' is prefixed with 'javac' AND runtime language is 'java'"
   );
 
   flatcc_builder_free(buf);

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1118,7 +1118,9 @@ UTEST(evaluator_integration, evaluate_generated_header_if_available) {
 static plcs_evaluation_result g_last_action_res = PLCS_EVAL_RESULT_ABSTAIN;
 static plcs_uuid g_last_policy_id;
 static int64_t g_last_policy_version;
-static const char *g_last_policy_description;
+// Copy policy_description into a buffer rather than storing the pointer
+static char g_last_policy_description_buf[512];
+static const char *const g_last_policy_description = g_last_policy_description_buf;
 
 static plcs_errors test_action_capture(
     plcs_evaluation_result res,
@@ -1138,7 +1140,7 @@ static plcs_errors test_action_capture(
   g_last_action_res = res;
   g_last_policy_id = policy_id;
   g_last_policy_version = policy_version;
-  g_last_policy_description = policy_description;
+  snprintf(g_last_policy_description_buf, sizeof(g_last_policy_description_buf), "%s", policy_description);
   return PLCS_ESUCCESS;
 }
 
@@ -1202,7 +1204,7 @@ UTEST(evaluator_integration, evaluate_pod_label_policy_end_to_end_match) {
   g_last_action_res = PLCS_EVAL_RESULT_ABSTAIN;
   g_last_policy_id = (plcs_uuid){0};
   g_last_policy_version = 0;
-  g_last_policy_description = NULL;
+  g_last_policy_description_buf[0] = 0;
 
   int prc = plcs_eval_ctx_register_action(test_action_capture, PLCS_ACTION_INJECT_ALLOW);
   ASSERT_EQ(prc, PLCS_ESUCCESS);
@@ -1241,7 +1243,7 @@ UTEST(evaluator_integration, evaluate_pod_label_policy_end_to_end_no_match) {
   g_last_action_res = PLCS_EVAL_RESULT_ABSTAIN;
   g_last_policy_id = (plcs_uuid){0};
   g_last_policy_version = 0;
-  g_last_policy_description = NULL;
+  g_last_policy_description_buf[0] = 0;
 
   int prc = plcs_eval_ctx_register_action(test_action_capture, PLCS_ACTION_INJECT_ALLOW);
   ASSERT_EQ(prc, PLCS_ESUCCESS);
@@ -1365,7 +1367,7 @@ static int setup_and_of_or_policy_context(const char *process_exe, const char *l
 
   g_allow_called = 0;
   g_last_action_res = PLCS_EVAL_RESULT_ABSTAIN;
-  g_last_policy_description = NULL;
+  g_last_policy_description_buf[0] = 0;
 
   return plcs_eval_ctx_register_action(test_action_capture, PLCS_ACTION_INJECT_ALLOW) |
          plcs_eval_ctx_register_str_evaluator(plcs_default_string_evaluator, PLCS_STR_EVAL_PROCESS_EXE) |

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -80,7 +80,7 @@ extern plcs_evaluation_result DoOr(plcs_evaluation_result a, plcs_evaluation_res
 extern plcs_evaluation_result DoNot(plcs_evaluation_result res);
 extern plcs_evaluation_result
 DoOper(dd_ns(BoolOperation_enum_t) oper, plcs_evaluation_result a, plcs_evaluation_result b);
-extern plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node);
+extern plcs_evaluation_result composite_evaluator(dd_ns(CompositeNode_table_t) node, int depth, void *rule);
 
 extern void plcs_eval_ctx_reset(void);
 
@@ -865,7 +865,7 @@ UTEST(evaluator, test_DoOper_basic_operations) {
 
 UTEST(evaluator, test_composite_evaluator_null_input) {
   /* Test with NULL node */
-  int res = composite_evaluator(NULL);
+  int res = composite_evaluator(NULL, 0, NULL);
   ASSERT_EQ(res, PLCS_EVAL_RESULT_ABSTAIN);
 }
 
@@ -1225,7 +1225,7 @@ UTEST(evaluator_integration, evaluate_pod_label_policy_end_to_end_match) {
   ASSERT_EQ(g_last_policy_id.hi, (uint64_t)0x0102030405060708ULL);
   ASSERT_EQ(g_last_policy_id.lo, (uint64_t)0x1112131415161718ULL);
   ASSERT_EQ(g_last_policy_version, (int64_t)1234567800);
-  ASSERT_STREQ(g_last_policy_description, "k8s pod-label policy");
+  ASSERT_STREQ(g_last_policy_description, "pod label is 'app=nginx'");
 
   flatcc_builder_free(buf);
   plcs_eval_ctx_reset();
@@ -1265,6 +1265,204 @@ UTEST(evaluator_integration, evaluate_pod_label_policy_end_to_end_no_match) {
   ASSERT_EQ(g_last_policy_id.lo, (uint64_t)0x1112131415161718ULL);
   ASSERT_EQ(g_last_policy_version, (int64_t)1234567800);
   ASSERT_STREQ(g_last_policy_description, "k8s pod-label policy");
+
+  flatcc_builder_free(buf);
+  plcs_eval_ctx_reset();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Integration tests for the matched rule description                         */
+/* -------------------------------------------------------------------------- */
+
+/* Every node in the fixture below carries this as its authored description. The engine
+ * generates descriptions from the evaluators instead, so this must never show up. */
+#define UNUSED_AUTHORED_DESCRIPTION "authored description that must be ignored"
+
+/* Serialize a one-policy buffer whose rules are:                                  */
+/*                                                                                 */
+/*   CompositeNode(BOOL_AND)                                                       */
+/*     ├─ CompositeNode(BOOL_OR)                                                   */
+/*     │    ├─ StrEvaluator(PROCESS_EXE, CMP_EXACT,  "java")                       */
+/*     │    └─ StrEvaluator(PROCESS_EXE, CMP_PREFIX, "python")                     */
+/*     └─ StrEvaluator(RUNTIME_LANGUAGE, CMP_EXACT,  "java")                       */
+/*                                                                                 */
+/* Caller owns *out_buf (flatcc_builder_free). */
+static dd_wls_NodeTypeWrapper_ref_t build_str_leaf(
+    flatcc_builder_t *b,
+    dd_wls_StringEvaluators_enum_t evaluator,
+    dd_wls_CmpTypeSTR_enum_t cmp,
+    const char *value
+) {
+  dd_wls_StrEvaluator_ref_t str =
+      dd_wls_StrEvaluator_create(b, evaluator, cmp, flatbuffers_string_create_str(b, value));
+  dd_wls_EvaluatorNode_ref_t leaf = dd_wls_EvaluatorNode_create(
+      b, flatbuffers_string_create_str(b, UNUSED_AUTHORED_DESCRIPTION), dd_wls_EvaluatorType_as_StrEvaluator(str)
+  );
+  return dd_wls_NodeTypeWrapper_create(b, dd_wls_NodeType_as_EvaluatorNode(leaf));
+}
+
+static dd_wls_NodeTypeWrapper_ref_t build_composite(
+    flatcc_builder_t *b,
+    dd_wls_BoolOperation_enum_t oper,
+    dd_wls_NodeTypeWrapper_ref_t first,
+    dd_wls_NodeTypeWrapper_ref_t second
+) {
+  flatbuffers_string_ref_t desc = flatbuffers_string_create_str(b, UNUSED_AUTHORED_DESCRIPTION);
+
+  dd_wls_NodeTypeWrapper_vec_start(b);
+  dd_wls_NodeTypeWrapper_vec_push(b, first);
+  dd_wls_NodeTypeWrapper_vec_push(b, second);
+  dd_wls_NodeTypeWrapper_vec_ref_t children = dd_wls_NodeTypeWrapper_vec_end(b);
+
+  return dd_wls_NodeTypeWrapper_create(
+      b, dd_wls_NodeType_as_CompositeNode(dd_wls_CompositeNode_create(b, desc, oper, children))
+  );
+}
+
+static void build_and_of_or_policy_buffer(void **out_buf, size_t *out_sz) {
+  flatcc_builder_t b;
+  flatcc_builder_init(&b);
+
+  dd_wls_NodeTypeWrapper_ref_t or_wrap = build_composite(
+      &b, dd_wls_BoolOperation_BOOL_OR,
+      build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_EXACT, "java"),
+      build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_PREFIX, "python")
+  );
+  dd_wls_NodeTypeWrapper_ref_t language_wrap =
+      build_str_leaf(&b, dd_wls_StringEvaluators_RUNTIME_LANGUAGE, dd_wls_CmpTypeSTR_CMP_EXACT, "java");
+
+  dd_wls_NodeTypeWrapper_ref_t rules = build_composite(&b, dd_wls_BoolOperation_BOOL_AND, or_wrap, language_wrap);
+
+  dd_wls_Action_start(&b);
+  dd_wls_Action_action_add(&b, dd_wls_ActionId_INJECT_ALLOW);
+  dd_wls_Action_ref_t action = dd_wls_Action_end(&b);
+  dd_wls_Action_vec_start(&b);
+  dd_wls_Action_vec_push(&b, action);
+  dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_end(&b);
+
+  dd_wls_UUID_t id;
+  dd_wls_UUID_assign(&id, 0ULL, 0ULL);
+  dd_wls_Policy_ref_t policy =
+      dd_wls_Policy_create(&b, flatbuffers_string_create_str(&b, "java policy"), rules, actions, &id, 1);
+
+  dd_wls_Policy_vec_start(&b);
+  dd_wls_Policy_vec_push(&b, policy);
+  dd_wls_Policies_create_as_root(&b, dd_wls_Policy_vec_end(&b));
+
+  *out_buf = flatcc_builder_finalize_buffer(&b, out_sz);
+  flatcc_builder_clear(&b);
+}
+
+/* Registers the capture action plus the two string evaluators the AND-of-OR policy
+ * needs, and describes the workload it should be evaluated against. Returns
+ * PLCS_ESUCCESS when everything was registered. */
+static int setup_and_of_or_policy_context(const char *process_exe, const char *language) {
+  int rc = plcs_eval_ctx_init();
+  if (rc != PLCS_ESUCCESS && rc != PLCS_EINITIZLIED) {
+    return rc;
+  }
+  plcs_eval_ctx_reset();
+
+  g_allow_called = 0;
+  g_last_action_res = PLCS_EVAL_RESULT_ABSTAIN;
+  g_last_policy_description = NULL;
+
+  return plcs_eval_ctx_register_action(test_action_capture, PLCS_ACTION_INJECT_ALLOW) |
+         plcs_eval_ctx_register_str_evaluator(plcs_default_string_evaluator, PLCS_STR_EVAL_PROCESS_EXE) |
+         plcs_eval_ctx_register_str_evaluator(plcs_default_string_evaluator, PLCS_STR_EVAL_RUNTIME_LANGUAGE) |
+         plcs_eval_ctx_set_str_eval_param(PLCS_STR_EVAL_PROCESS_EXE, process_exe) |
+         plcs_eval_ctx_set_str_eval_param(PLCS_STR_EVAL_RUNTIME_LANGUAGE, language);
+}
+
+UTEST(evaluator_integration, matched_rule_joins_and_children_and_takes_first_true_or_child) {
+  ASSERT_EQ(setup_and_of_or_policy_context("python3.11", "java"), PLCS_ESUCCESS);
+
+  void *buf = NULL;
+  size_t sz = 0;
+  build_and_of_or_policy_buffer(&buf, &sz);
+
+  int eval_rc = plcs_evaluate_buffer((const uint8_t *)buf, sz);
+  ASSERT_EQ(eval_rc, PLCS_ESUCCESS);
+  ASSERT_EQ(g_allow_called, 1);
+  ASSERT_EQ((int)g_last_action_res, (int)PLCS_EVAL_RESULT_TRUE);
+  /* The AND node contributes both of its children; the OR node contributes only the
+   * "python" branch, since the "java" branch evaluated to FALSE. */
+  ASSERT_STREQ(
+      g_last_policy_description,
+      "process executable 'python3.11' is prefixed with 'python' AND runtime language is 'java'"
+  );
+
+  flatcc_builder_free(buf);
+  plcs_eval_ctx_reset();
+}
+
+UTEST(evaluator_integration, matched_rule_falls_back_to_policy_description_when_nothing_matched) {
+  ASSERT_EQ(setup_and_of_or_policy_context("ruby", "java"), PLCS_ESUCCESS);
+
+  void *buf = NULL;
+  size_t sz = 0;
+  build_and_of_or_policy_buffer(&buf, &sz);
+
+  int eval_rc = plcs_evaluate_buffer((const uint8_t *)buf, sz);
+  ASSERT_EQ(eval_rc, PLCS_ESUCCESS);
+  ASSERT_EQ(g_allow_called, 1);
+  ASSERT_EQ((int)g_last_action_res, (int)PLCS_EVAL_RESULT_FALSE);
+  /* No rule triggered, so there is nothing to describe but the policy itself. */
+  ASSERT_STREQ(g_last_policy_description, "java policy");
+
+  flatcc_builder_free(buf);
+  plcs_eval_ctx_reset();
+}
+
+/* A single condition whose value is longer than the whole description buffer. */
+static void build_long_value_policy_buffer(const char *value, void **out_buf, size_t *out_sz) {
+  flatcc_builder_t b;
+  flatcc_builder_init(&b);
+
+  dd_wls_NodeTypeWrapper_ref_t rules =
+      build_str_leaf(&b, dd_wls_StringEvaluators_PROCESS_EXE, dd_wls_CmpTypeSTR_CMP_EXACT, value);
+
+  dd_wls_Action_start(&b);
+  dd_wls_Action_action_add(&b, dd_wls_ActionId_INJECT_ALLOW);
+  dd_wls_Action_ref_t action = dd_wls_Action_end(&b);
+  dd_wls_Action_vec_start(&b);
+  dd_wls_Action_vec_push(&b, action);
+  dd_wls_Action_vec_ref_t actions = dd_wls_Action_vec_end(&b);
+
+  dd_wls_UUID_t id;
+  dd_wls_UUID_assign(&id, 0ULL, 0ULL);
+  dd_wls_Policy_ref_t policy =
+      dd_wls_Policy_create(&b, flatbuffers_string_create_str(&b, "long value policy"), rules, actions, &id, 1);
+
+  dd_wls_Policy_vec_start(&b);
+  dd_wls_Policy_vec_push(&b, policy);
+  dd_wls_Policies_create_as_root(&b, dd_wls_Policy_vec_end(&b));
+
+  *out_buf = flatcc_builder_finalize_buffer(&b, out_sz);
+  flatcc_builder_clear(&b);
+}
+
+UTEST(evaluator_integration, matched_rule_marks_a_truncated_description_with_an_ellipsis) {
+  char long_value[900];
+  memset(long_value, 'x', sizeof(long_value) - 1);
+  long_value[sizeof(long_value) - 1] = '\0';
+
+  ASSERT_EQ(setup_and_of_or_policy_context(long_value, "java"), PLCS_ESUCCESS);
+
+  void *buf = NULL;
+  size_t sz = 0;
+  build_long_value_policy_buffer(long_value, &buf, &sz);
+
+  int eval_rc = plcs_evaluate_buffer((const uint8_t *)buf, sz);
+  ASSERT_EQ(eval_rc, PLCS_ESUCCESS);
+  ASSERT_EQ(g_allow_called, 1);
+  ASSERT_EQ((int)g_last_action_res, (int)PLCS_EVAL_RESULT_TRUE);
+
+  /* The rule matched, so this is a generated description, cut short and marked. */
+  size_t described_len = strlen(g_last_policy_description);
+  ASSERT_LT(described_len, strlen(long_value));
+  ASSERT_STREQ(g_last_policy_description + described_len - 3, "...");
+  ASSERT_TRUE(strncmp(g_last_policy_description, "process executable is 'xxx", 26) == 0);
 
   flatcc_builder_free(buf);
   plcs_eval_ctx_reset();

--- a/c/src/test/test_evaluator.c
+++ b/c/src/test/test_evaluator.c
@@ -1445,15 +1445,22 @@ static void build_long_value_policy_buffer(const char *value, void **out_buf, si
 }
 
 UTEST(evaluator_integration, matched_rule_marks_a_truncated_description_with_an_ellipsis) {
-  char long_value[900];
-  memset(long_value, 'x', sizeof(long_value) - 1);
-  long_value[sizeof(long_value) - 1] = '\0';
+  /* A deep executable path, which is the realistic way a description outgrows the buffer.
+   * Only the head needs to be recognizable; the padding just needs to clear the matched-rule
+   * buffer's internal 512-byte cap. */
+  static const char path_head[] = "/opt/datadog/embedded/lib/python3.11/";
+  char long_path[600];
+  size_t head_len = sizeof(path_head) - 1;
+  for (size_t ix = 0; ix < sizeof(long_path) - 1; ++ix) {
+    long_path[ix] = ix < head_len ? path_head[ix] : 'a';
+  }
+  long_path[sizeof(long_path) - 1] = '\0';
 
-  ASSERT_EQ(setup_and_of_or_policy_context(long_value, "java"), PLCS_ESUCCESS);
+  ASSERT_EQ(setup_and_of_or_policy_context(long_path, "python"), PLCS_ESUCCESS);
 
   void *buf = NULL;
   size_t sz = 0;
-  build_long_value_policy_buffer(long_value, &buf, &sz);
+  build_long_value_policy_buffer(long_path, &buf, &sz);
 
   int eval_rc = plcs_evaluate_buffer((const uint8_t *)buf, sz);
   ASSERT_EQ(eval_rc, PLCS_ESUCCESS);
@@ -1462,9 +1469,12 @@ UTEST(evaluator_integration, matched_rule_marks_a_truncated_description_with_an_
 
   /* The rule matched, so this is a generated description, cut short and marked. */
   size_t described_len = strlen(g_last_policy_description);
-  ASSERT_LT(described_len, strlen(long_value));
+  ASSERT_LT(described_len, strlen(long_path));
   ASSERT_STREQ(g_last_policy_description + described_len - 3, "...");
-  ASSERT_TRUE(strncmp(g_last_policy_description, "process executable is 'xxx", 26) == 0);
+
+  /* the head survived: truncation dropped the tail, not the front */
+  static const char expected_head[] = "process executable is '/opt/datadog/embedded/lib/python3.11/";
+  ASSERT_STRNEQ(g_last_policy_description, expected_head, sizeof(expected_head) - 1);
 
   flatcc_builder_free(buf);
   plcs_eval_ctx_reset();

--- a/c/src/wire/action.h
+++ b/c/src/wire/action.h
@@ -70,7 +70,8 @@ static inline dd_ns(ActionId_enum_t) dd_action_to_wire(enum plcs_actions v) {
  * @param action_id           Integer ID of the action.
  * @param policy_id           Policy ID that produced this action.
  * @param policy_version      Policy version that produced this action.
- * @param policy_description  Policy description that produced this action.
+ * @param policy_description  Description of the rule that triggered this action, falling back
+ *                            to the policy's own description when no rule matched.
  *
  * @return A `plcs_errors` status code.
  */

--- a/c/src/wire/evaluator_types.h
+++ b/c/src/wire/evaluator_types.h
@@ -47,7 +47,7 @@ extern "C" {
 
 static inline dd_ns(CmpTypeSTR_enum_t) dd_strcmp_to_wire(enum plcs_string_comparator v) {
 /* Map your public enum -> vendor numeric value. */
-#define ENUM_VAL(ID, X) [PLCS_STR_CMP_##ID] = dd_ns(CmpTypeSTR_CMP_##ID),
+#define ENUM_VAL(ID, X, LABEL) [PLCS_STR_CMP_##ID] = dd_ns(CmpTypeSTR_CMP_##ID),
   static const int map[PLCS_STR_CMP__COUNT] = {PLCS_LIST_STRING_COMPARATORS(ENUM_VAL)};
 #undef ENUM_VAL
   _Static_assert(
@@ -58,7 +58,7 @@ static inline dd_ns(CmpTypeSTR_enum_t) dd_strcmp_to_wire(enum plcs_string_compar
 }
 
 static inline dd_ns(CmpTypeNUM_enum_t) dd_numcmp_to_wire(enum plcs_numeric_comparator v) {
-#define ENUM_VAL(ID, X) [PLCS_NUM_CMP_##ID] = dd_ns(CmpTypeNUM_CMP_##ID),
+#define ENUM_VAL(ID, X, LABEL) [PLCS_NUM_CMP_##ID] = dd_ns(CmpTypeNUM_CMP_##ID),
   static const int map[PLCS_NUM_CMP__COUNT] = {PLCS_LIST_NUMERIC_COMPARATOR(ENUM_VAL)};
 #undef ENUM_VAL
   _Static_assert(
@@ -70,7 +70,7 @@ static inline dd_ns(CmpTypeNUM_enum_t) dd_numcmp_to_wire(enum plcs_numeric_compa
 
 static inline dd_ns(StringEvaluators_enum_t) dd_streval_to_wire(enum plcs_string_evaluators v) {
   /* Keep indices aligned with your public enum order. */
-#define ENUM_VAL(ID, X) [PLCS_STR_EVAL_##ID] = dd_ns(StringEvaluators_##ID),
+#define ENUM_VAL(ID, X, LABEL) [PLCS_STR_EVAL_##ID] = dd_ns(StringEvaluators_##ID),
   static const int map[PLCS_STR_EVAL__COUNT] = {PLCS_LIST_STRING_EVALUATORS(ENUM_VAL)};
 #undef ENUM_VAL
   _Static_assert(
@@ -81,7 +81,7 @@ static inline dd_ns(StringEvaluators_enum_t) dd_streval_to_wire(enum plcs_string
 }
 
 static inline dd_ns(NumericEvaluators_enum_t) dd_numeval_to_wire(enum plcs_numeric_evaluators v) {
-#define ENUM_VAL(ID, X) [PLCS_NUM_EVAL_##ID] = dd_ns(NumericEvaluators_##ID),
+#define ENUM_VAL(ID, X, LABEL) [PLCS_NUM_EVAL_##ID] = dd_ns(NumericEvaluators_##ID),
   static const int map[PLCS_NUM_EVAL__COUNT] = {PLCS_LIST_NUMERIC_EVALUATORS(ENUM_VAL)};
 #undef ENUM_VAL
   _Static_assert(


### PR DESCRIPTION
This PR has the `policy_description` argument to the action callback now carry a description of the rule that actually matched during WLS evaluation, generated from the evaluators themselves so it includes the context values they saw. An example of a rule description would be `process executable 'javac17' is prefixed with 'javac' AND runtime language is 'java'`.

### How the description is composed
- Evaluator node — `<evaluator label> '<context value>' <comparator label> '<policy value>'`. Labels come from a new third column on the `PLCS_LIST_*` X-macro lists in `evaluator_types.h`, so they can't drift from the enums.
- AND composite node — joins every child with `" AND "` (an AND is only TRUE when all children are)
- OR composite node — contributes only the first child that evaluated TRUE (OR short-circuits).
- Exact match — collapses to `<label> is '<value>'` rather than repeating the same value twice.
- No match — falls back to the policy's description, unchanged from today.

The whole thing follows from one rule: a node describes itself only when it evaluates to TRUE. AND/OR behavior then falls out of the existing short-circuiting rather than needing separate handling.

### Testing
- Three new integration tests: tested AND and OR composite nodes matching, fallback when nothing matches, and truncation when description is too long.
- Verified end to end against real flatbuffer files. `basic-reader` and `mmap-reader` now print the matched rule.                                                               