### PR TITLE
fix(c): update observing_action to current action callback signature

### DIFF
--- a/c/src/test/test_invalid_action_isolation.c
+++ b/c/src/test/test_invalid_action_isolation.c
@@ -109,12 +109,18 @@ static plcs_errors observing_action(
     char *values[],
     size_t value_count,
     const char *description,
-    int action_id
+    int action_id,
+    plcs_uuid policy_id,
+    int64_t policy_version,
+    const char *policy_description
 ) {
   (void)values;
   (void)value_count;
   (void)description;
   (void)action_id;
+  (void)policy_id;
+  (void)policy_version;
+  (void)policy_description;
   ++observed_calls;
   observed_result = result;
   return PLCS_ESUCCESS;


### PR DESCRIPTION
## What

Widens `observing_action` in `c/src/test/test_invalid_action_isolation.c` from 5 to the current 8 parameters of `plcs_action_function_ptr`.

## Why

`main` is red on all five `build-libpolicies-*` jobs. The test registers a callback with the old signature:

```
c/src/test/test_invalid_action_isolation.c:132:48: error: incompatible function pointer types
  passing   plcs_errors (plcs_evaluation_result, char **, size_t, const char *, int)
  to        plcs_action_function_ptr
      = plcs_errors (*)(..., int, plcs_uuid, int64_t, const char *)
```

`plcs_action_function_ptr` gained `policy_id`, `policy_version`, and `policy_description`. gcc and clang reject the mismatch under `-Wincompatible-pointer-types`, and MSVC promotes warning C4113 to an error. The signature now matches the callbacks in `test_evaluator.c`.

This also unblocks in-flight PRs, whose `pull_request` runs build the merge commit and inherit the break (e.g. #90).

## Validation

Built and ran the suite in the CI container on arm64:

- `make docker-run "make -C c test-build"` with `CMAKE_PRESET=clang-ci` — builds clean
- `dd-policy-engine.unit-tests --random-order` — 63/63 pass, including `policy_validation.unknown_actions_are_skipped_and_valid_action_runs`
- `clang-format --dry-run -Werror` on the changed file — clean