### PR TITLE
fix(dd-compile-policy): allow schema updates via datadog-apm-inject without a compiler bump

### DIFF
--- a/dd-compile-policy/Makefile
+++ b/dd-compile-policy/Makefile
@@ -190,6 +190,7 @@ endif
 # checkout and exercises the same artifact CI ships.
 test: build
 	@$(PYTHON) tests/forward_compat_test.py $(OUT)
+	@$(PYTHON) tests/injector_schema_fallback_test.py $(OUT)
 
 # Verify by unmarshalling compiled policy to JSON
 verify_json:

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -19,7 +19,8 @@
 // new evaluators without an Agent/compiler version bump.
 #if defined(_WIN32)
 constexpr char kInjectorSchemaPath[] =
-    "C:\\ProgramData\\Datadog\\Installer\\packages\\datadog-apm-inject\\stable\\dll\\policy.bfbs";
+    "C:\\ProgramData\\Datadog\\Installer\\packages\\datadog-apm-"
+    "inject\\stable\\dll\\policy.bfbs";
 #else
 constexpr char kInjectorSchemaPath[] =
     "/opt/datadog-packages/datadog-apm-inject/stable/inject/policy.bfbs";
@@ -111,7 +112,7 @@ int main(int argc, char *argv[]) {
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
   } else if (flatbuffers::LoadFile(kInjectorSchemaPath, true,
-                                    &schema_file_buf)) {
+                                   &schema_file_buf)) {
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
   }

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -12,6 +12,14 @@
 #include "cxxopts.hpp"
 #include "policy_schema_bfbs.h" // Contains `schema_policy_bfbs` and `schema_policy_bfbs_len`
 
+// dd-compile-policy ships bundled inside the Agent, which pins it
+// to a specific version, so its baked-in schema can lag newly added
+// string/numeric evaluators. The datadog-apm-inject package updates on a
+// separate cadence and can drop a newer schema at this fixed path to unblock
+// new evaluators without an Agent/compiler version bump.
+constexpr char kInjectorSchemaPath[] =
+    "/opt/datadog-packages/datadog-apm-inject/stable/inject/policy.bfbs";
+
 int main(int argc, char *argv[]) {
   std::string json_str;
   std::string json_file;
@@ -79,8 +87,11 @@ int main(int argc, char *argv[]) {
   // (`*_UNKNOWN`), which the engine treats as "abstain".
   parser.opts.skip_unexpected_fields_in_json = true;
 
-  // Load binary schema (.bfbs): a custom schema file if provided, otherwise
-  // the schema built into this binary.
+  // Load binary schema (.bfbs), in order of preference:
+  //   1. an explicit --schema-file, if provided (hard error if unreadable);
+  //   2. the schema at kInjectorSchemaPath, updated independently of this
+  //      binary by the injector (silently skipped if absent/unreadable);
+  //   3. the schema built into this binary.
   const uint8_t *schema_bytes =
       reinterpret_cast<const uint8_t *>(schema_policy_bfbs);
   size_t schema_len = schema_policy_bfbs_len;
@@ -92,6 +103,10 @@ int main(int argc, char *argv[]) {
       std::cerr << "failed to open schema file " << schema_path << std::endl;
       return EXIT_FAILURE;
     }
+    schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
+    schema_len = schema_file_buf.size();
+  } else if (flatbuffers::LoadFile(kInjectorSchemaPath, true,
+                                    &schema_file_buf)) {
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
   }

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -17,8 +17,13 @@
 // string/numeric evaluators. The datadog-apm-inject package updates on a
 // separate cadence and can drop a newer schema at this fixed path to unblock
 // new evaluators without an Agent/compiler version bump.
+#if defined(_WIN32)
+constexpr char kInjectorSchemaPath[] =
+    "C:\\ProgramData\\Datadog\\Installer\\packages\\datadog-apm-inject\\stable\\dll\\policy.bfbs";
+#else
 constexpr char kInjectorSchemaPath[] =
     "/opt/datadog-packages/datadog-apm-inject/stable/inject/policy.bfbs";
+#endif
 
 int main(int argc, char *argv[]) {
   std::string json_str;

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -111,16 +111,16 @@ int main(int argc, char *argv[]) {
     }
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
-    std::cerr << "using schema from --schema-file: " << schema_path
+    std::cout << "using schema from --schema-file: " << schema_path
                << std::endl;
   } else if (flatbuffers::LoadFile(kInjectorSchemaPath, true,
                                    &schema_file_buf)) {
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
-    std::cerr << "using schema from injector path: " << kInjectorSchemaPath
+    std::cout << "using schema from injector path: " << kInjectorSchemaPath
                << std::endl;
   } else {
-    std::cerr << "using built-in schema" << std::endl;
+    std::cout << "using built-in schema" << std::endl;
   }
 
   if (!parser.Deserialize(schema_bytes, schema_len)) {

--- a/dd-compile-policy/src/compile_policy.cpp
+++ b/dd-compile-policy/src/compile_policy.cpp
@@ -111,10 +111,16 @@ int main(int argc, char *argv[]) {
     }
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
+    std::cerr << "using schema from --schema-file: " << schema_path
+               << std::endl;
   } else if (flatbuffers::LoadFile(kInjectorSchemaPath, true,
                                    &schema_file_buf)) {
     schema_bytes = reinterpret_cast<const uint8_t *>(schema_file_buf.data());
     schema_len = schema_file_buf.size();
+    std::cerr << "using schema from injector path: " << kInjectorSchemaPath
+               << std::endl;
+  } else {
+    std::cerr << "using built-in schema" << std::endl;
   }
 
   if (!parser.Deserialize(schema_bytes, schema_len)) {

--- a/dd-compile-policy/tests/injector_schema_fallback_test.py
+++ b/dd-compile-policy/tests/injector_schema_fallback_test.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2.0 License. This product includes software developed at
+# Datadog (https://www.datadoghq.com/).
+#
+# Copyright 2025-Present Datadog, Inc.
+"""Injector-package schema fallback for dd-compile-policy.
+
+The Agent pins dd-compile-policy to a specific version, so its baked-in schema
+can lag newly added evaluators. datadog-apm-inject updates on a separate
+cadence and can drop a fresher schema at a fixed, platform-specific path; the
+compiler should prefer it over the one baked into the binary, but an explicit
+--schema-file must still win over both.
+
+Usage: injector_schema_fallback_test.py [path-to-dd-compile-policy]
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Mirrors kInjectorSchemaPath in src/compile_policy.cpp.
+if os.name == "nt":
+    INJECTOR_SCHEMA_PATH = (
+        r"C:\ProgramData\Datadog\Installer\packages\datadog-apm-inject\stable\dll\policy.bfbs"
+    )
+else:
+    INJECTOR_SCHEMA_PATH = "/opt/datadog-packages/datadog-apm-inject/stable/inject/policy.bfbs"
+
+BASELINE = {
+    "policies": [
+        {
+            "description": "injector schema fallback baseline",
+            "rules": {
+                "node_type": "CompositeNode",
+                "node": {
+                    "description": "root",
+                    "op": "BOOL_AND",
+                    "children": [
+                        {
+                            "node_type": "EvaluatorNode",
+                            "node": {
+                                "description": "leaf",
+                                "eval_type": "StrEvaluator",
+                                "eval": {
+                                    "id": "OS",
+                                    "cmp": "CMP_EXACT",
+                                    "value": "linux",
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+            "actions": [
+                {"action": "INJECT_ALLOW", "description": "act", "values": ["x"]}
+            ],
+            "version": 1,
+        }
+    ]
+}
+
+
+class Runner:
+    def __init__(self, binary, work_dir):
+        self.binary = binary
+        self.work_dir = work_dir
+        self.failures = 0
+
+    def ok(self, name, detail):
+        print("[ok]   {}: {}".format(name, detail))
+
+    def fail(self, name, detail):
+        print("[FAIL] {}".format(name))
+        if detail:
+            print("       {}".format(detail.strip()))
+        self.failures += 1
+
+    def compile(self, name, schema_file=None):
+        src = os.path.join(self.work_dir, name + ".json")
+        out = os.path.join(self.work_dir, name + ".bin")
+        with open(src, "w") as handle:
+            handle.write(json.dumps(BASELINE))
+        cmd = [self.binary, "--input-file", src, "--output-file", out]
+        if schema_file:
+            cmd += ["--schema-file", schema_file]
+        proc = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+        )
+        return proc.returncode == 0, proc.stdout or "", out
+
+    def assert_compiles(self, name, schema_file, detail):
+        ok, diagnostics, _ = self.compile(name, schema_file)
+        if ok:
+            self.ok(name, detail)
+        else:
+            self.fail(name, diagnostics)
+
+    def assert_fails(self, name, schema_file, detail):
+        ok, diagnostics, _ = self.compile(name, schema_file)
+        if ok:
+            self.fail(name + ": expected failure, but it compiled", detail)
+        else:
+            self.ok(name, detail)
+
+
+def default_binary():
+    name = "dd-compile-policy.exe" if os.name == "nt" else "dd-compile-policy"
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, os.pardir, "bin", name)
+
+
+def default_builtin_schema():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, os.pardir, "schema", "policy.bfbs")
+
+
+def main(argv):
+    binary = argv[1] if len(argv) > 1 else os.environ.get("BIN") or default_binary()
+    if not os.path.isfile(binary):
+        sys.stderr.write(
+            "[!] dd-compile-policy not found at {} (run 'make build' first)\n".format(binary)
+        )
+        return 1
+
+    if os.path.exists(INJECTOR_SCHEMA_PATH):
+        print(
+            "[i] skipping: {} already exists (looks like a real install, "
+            "refusing to touch it)".format(INJECTOR_SCHEMA_PATH)
+        )
+        return 0
+
+    injector_dir = os.path.dirname(INJECTOR_SCHEMA_PATH)
+    try:
+        os.makedirs(injector_dir, exist_ok=True)
+        with open(INJECTOR_SCHEMA_PATH, "wb") as handle:
+            handle.write(b"")
+    except OSError as exc:
+        print(
+            "[i] skipping: cannot write {} ({}); rerun as root/in the build "
+            "container to exercise this tier".format(INJECTOR_SCHEMA_PATH, exc)
+        )
+        try:
+            os.remove(INJECTOR_SCHEMA_PATH)
+        except OSError:
+            pass
+        return 0
+
+    good_schema = default_builtin_schema()
+    if not os.path.isfile(good_schema):
+        sys.stderr.write(
+            "[!] built schema not found at {} (run 'make build' first)\n".format(good_schema)
+        )
+        os.remove(INJECTOR_SCHEMA_PATH)
+        return 1
+
+    work_dir = tempfile.mkdtemp(prefix="dd-injector-schema-")
+    try:
+        run = Runner(binary, work_dir)
+        print("[i] dd-compile-policy injector schema fallback ({})".format(binary))
+
+        # An invalid (but present and readable) file at the injector path must
+        # be preferred over the baked-in schema when no --schema-file is
+        # given: the compile fails, proving the compiler actually tried to
+        # deserialize it rather than silently falling back.
+        with open(INJECTOR_SCHEMA_PATH, "wb") as handle:
+            handle.write(b"not a valid flatbuffers binary schema")
+        run.assert_fails(
+            "invalid-injector-schema-used-over-builtin",
+            None,
+            "corrupt injector schema rejected instead of silently using the built-in one",
+        )
+
+        # An explicit --schema-file must still win over the injector path,
+        # even when the injector path holds something invalid.
+        run.assert_compiles(
+            "explicit-schema-file-wins-over-injector-path",
+            good_schema,
+            "explicit --schema-file bypassed the corrupt injector schema",
+        )
+
+        # Once the injector path is empty/removed, the baked-in schema is
+        # used again (tier 3, unchanged default behavior).
+        os.remove(INJECTOR_SCHEMA_PATH)
+        run.assert_compiles(
+            "falls-back-to-builtin-when-injector-path-absent",
+            None,
+            "compiled using the schema baked into the binary",
+        )
+
+        if run.failures:
+            sys.stderr.write(
+                "[!] {} injector schema fallback check(s) failed\n".format(run.failures)
+            )
+            return 1
+        print("[i] all injector schema fallback checks passed")
+        return 0
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        try:
+            os.remove(INJECTOR_SCHEMA_PATH)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
The Datadog Agent pins `dd-compile-policy` to a fixed version, so its baked-in policy schema can lag newly added string/numeric evaluators until the next Agent bump. This adds a fallback chain so a newer schema can reach the compiler sooner via the `datadog-apm-inject` package. 

First, the compiler checks for a schema that's passed in through the command line flag `--schema-file`. If there is no `--schema-file` flag, then the compiler will read the schema that's at a fixed path within `datadog-apm-inject`. For Linux, it's `/opt/datadog-packages/datadog-apm-inject/stable/inject/policy.bfbs`. For Windows, it's `C:\ProgramData\Datadog\Installer\packages\datadog-apm-inject\stable\dll\policy.bfbs`. If there is no schema at this path, then the compiler will use the schema baked into the binary at build time.

## Testing
- Added `tests/injector_schema_fallback_test.py`, wired into the `test` Makefile target, covering both the Linux and Windows fallback paths:
  - an invalid schema at the injector path is used (and rejected) instead of silently falling back to the baked-in one
  - an explicit `--schema-file` still wins over a present injector schema
  - compilation falls back to the baked-in schema when the injector path is absent.
- The test skips itself defensively if the real system path already exists (avoids touching a real install) or if writing to it fails with a permission error.
